### PR TITLE
Upgrade to Jasmine 1.1

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,7 @@ For information on how to use jasmine-plugin, check out its [documentation](http
 
 ## Current Version Info
 
-The plugin's version numbering will mirror the version of Jasmine that backs it. The latest version of the plugin points to Jasmine 1.0.2, so its version number is **1.0.2-beta-5**.
+The plugin's version numbering will mirror the version of Jasmine that backs it. The latest version of the plugin points to Jasmine 1.1.0, so its version number is **1.1.0-beta-5**.
 
 If you want to point at snapshot releases of the plugin (note that I don't deploy them often), they're hosted on the [Sonatype OSS snapshot repository](https://oss.sonatype.org/service/local/repositories/snapshots).
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<groupId>com.github.searls</groupId>
 	<artifactId>jasmine-maven-plugin</artifactId>
-	<version>1.0.2-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 
 	<name>jasmine-maven-plugin</name>
@@ -38,7 +38,7 @@
 	</scm>
 
 	<properties>
-		<jasmine.version>1.0.2</jasmine.version>
+		<jasmine.version>1.1.0</jasmine.version>
 		<powermock.version>1.4.6</powermock.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>

--- a/src/main/resources/vendor/js/jasmine-html.js
+++ b/src/main/resources/vendor/js/jasmine-html.js
@@ -34,7 +34,7 @@ jasmine.TrivialReporter.prototype.reportRunnerStarting = function(runner) {
   this.outerDiv = this.createDom('div', { className: 'jasmine_reporter' },
       this.createDom('div', { className: 'banner' },
         this.createDom('div', { className: 'logo' },
-            this.createDom('a', { href: 'http://pivotal.github.com/jasmine/', target: "_blank" }, "Jasmine"),
+            this.createDom('span', { className: 'title' }, "Jasmine"),
             this.createDom('span', { className: 'version' }, runner.env.versionString())),
         this.createDom('div', { className: 'options' },
             "Show ",
@@ -110,7 +110,7 @@ jasmine.TrivialReporter.prototype.reportRunnerResults = function(runner) {
 jasmine.TrivialReporter.prototype.reportSuiteResults = function(suite) {
   var results = suite.results();
   var status = results.passed() ? 'passed' : 'failed';
-  if (results.totalCount == 0) { // todo: change this to check results.skipped
+  if (results.totalCount === 0) { // todo: change this to check results.skipped
     status = 'skipped';
   }
   this.suiteDivs[suite.id].className += " " + status;
@@ -183,6 +183,8 @@ jasmine.TrivialReporter.prototype.specFilter = function(spec) {
     paramMap[decodeURIComponent(p[0])] = decodeURIComponent(p[1]);
   }
 
-  if (!paramMap["spec"]) return true;
-  return spec.getFullName().indexOf(paramMap["spec"]) == 0;
+  if (!paramMap.spec) {
+    return true;
+  }
+  return spec.getFullName().indexOf(paramMap.spec) === 0;
 };

--- a/src/main/resources/vendor/js/jasmine.js
+++ b/src/main/resources/vendor/js/jasmine.js
@@ -1,10 +1,12 @@
+var isCommonJS = typeof window == "undefined";
+
 /**
  * Top level namespace for Jasmine, a lightweight JavaScript BDD/spec/testing framework.
  *
  * @namespace
  */
 var jasmine = {};
-
+if (isCommonJS) exports.jasmine = jasmine;
 /**
  * @private
  */
@@ -19,6 +21,12 @@ jasmine.unimplementedMethod_ = function() {
  * @private
  */
 jasmine.undefined = jasmine.___undefined___;
+
+/**
+ * Show diagnostic messages in the console if set to true
+ *
+ */
+jasmine.VERBOSE = false;
 
 /**
  * Default interval in milliseconds for event loop yields (e.g. to allow network activity or to refresh the screen with the HTML-based runner). Small values here may result in slow test running. Zero means no updates until all tests have completed.
@@ -72,7 +80,7 @@ jasmine.MessageResult = function(values) {
 
 jasmine.MessageResult.prototype.toString = function() {
   var text = "";
-  for(var i = 0; i < this.values.length; i++) {
+  for (var i = 0; i < this.values.length; i++) {
     if (i > 0) text += " ";
     if (jasmine.isString_(this.values[i])) {
       text += this.values[i];
@@ -89,9 +97,10 @@ jasmine.ExpectationResult = function(params) {
   this.passed_ = params.passed;
   this.expected = params.expected;
   this.actual = params.actual;
-
   this.message = this.passed_ ? 'Passed.' : params.message;
-  this.trace = this.passed_ ? '' : new Error(this.message);
+
+  var trace = (params.trace || new Error(this.message));
+  this.trace = this.passed_ ? '' : trace;
 };
 
 jasmine.ExpectationResult.prototype.toString = function () {
@@ -106,7 +115,8 @@ jasmine.ExpectationResult.prototype.passed = function () {
  * Getter for the Jasmine environment. Ensures one gets created
  */
 jasmine.getEnv = function() {
-  return jasmine.currentEnv_ = jasmine.currentEnv_ || new jasmine.Env();
+  var env = jasmine.currentEnv_ = jasmine.currentEnv_ || new jasmine.Env();
+  return env;
 };
 
 /**
@@ -116,7 +126,7 @@ jasmine.getEnv = function() {
  * @returns {Boolean}
  */
 jasmine.isArray_ = function(value) {
-  return jasmine.isA_("Array", value);  
+  return jasmine.isA_("Array", value);
 };
 
 /**
@@ -169,7 +179,7 @@ jasmine.pp = function(value) {
  * @returns {Boolean}
  */
 jasmine.isDomNode = function(obj) {
-  return obj['nodeType'] > 0;
+  return obj.nodeType > 0;
 };
 
 /**
@@ -405,7 +415,7 @@ jasmine.isSpy = function(putativeSpy) {
  * @param {Array} methodNames array of names of methods to make spies
  */
 jasmine.createSpyObj = function(baseName, methodNames) {
-  if (!jasmine.isArray_(methodNames) || methodNames.length == 0) {
+  if (!jasmine.isArray_(methodNames) || methodNames.length === 0) {
     throw new Error('createSpyObj requires a non-empty array of method names to create spies for');
   }
   var obj = {};
@@ -443,6 +453,7 @@ jasmine.log = function() {
 var spyOn = function(obj, methodName) {
   return jasmine.getEnv().currentSpec.spyOn(obj, methodName);
 };
+if (isCommonJS) exports.spyOn = spyOn;
 
 /**
  * Creates a Jasmine spec that will be added to the current suite.
@@ -460,6 +471,7 @@ var spyOn = function(obj, methodName) {
 var it = function(desc, func) {
   return jasmine.getEnv().it(desc, func);
 };
+if (isCommonJS) exports.it = it;
 
 /**
  * Creates a <em>disabled</em> Jasmine spec.
@@ -472,6 +484,7 @@ var it = function(desc, func) {
 var xit = function(desc, func) {
   return jasmine.getEnv().xit(desc, func);
 };
+if (isCommonJS) exports.xit = xit;
 
 /**
  * Starts a chain for a Jasmine expectation.
@@ -484,6 +497,7 @@ var xit = function(desc, func) {
 var expect = function(actual) {
   return jasmine.getEnv().currentSpec.expect(actual);
 };
+if (isCommonJS) exports.expect = expect;
 
 /**
  * Defines part of a jasmine spec.  Used in cominbination with waits or waitsFor in asynchrnous specs.
@@ -493,6 +507,7 @@ var expect = function(actual) {
 var runs = function(func) {
   jasmine.getEnv().currentSpec.runs(func);
 };
+if (isCommonJS) exports.runs = runs;
 
 /**
  * Waits a fixed time period before moving to the next block.
@@ -503,6 +518,7 @@ var runs = function(func) {
 var waits = function(timeout) {
   jasmine.getEnv().currentSpec.waits(timeout);
 };
+if (isCommonJS) exports.waits = waits;
 
 /**
  * Waits for the latchFunction to return true before proceeding to the next block.
@@ -514,6 +530,7 @@ var waits = function(timeout) {
 var waitsFor = function(latchFunction, optional_timeoutMessage, optional_timeout) {
   jasmine.getEnv().currentSpec.waitsFor.apply(jasmine.getEnv().currentSpec, arguments);
 };
+if (isCommonJS) exports.waitsFor = waitsFor;
 
 /**
  * A function that is called before each spec in a suite.
@@ -525,6 +542,7 @@ var waitsFor = function(latchFunction, optional_timeoutMessage, optional_timeout
 var beforeEach = function(beforeEachFunction) {
   jasmine.getEnv().beforeEach(beforeEachFunction);
 };
+if (isCommonJS) exports.beforeEach = beforeEach;
 
 /**
  * A function that is called after each spec in a suite.
@@ -536,6 +554,7 @@ var beforeEach = function(beforeEachFunction) {
 var afterEach = function(afterEachFunction) {
   jasmine.getEnv().afterEach(afterEachFunction);
 };
+if (isCommonJS) exports.afterEach = afterEach;
 
 /**
  * Defines a suite of specifications.
@@ -555,6 +574,7 @@ var afterEach = function(afterEachFunction) {
 var describe = function(description, specDefinitions) {
   return jasmine.getEnv().describe(description, specDefinitions);
 };
+if (isCommonJS) exports.describe = describe;
 
 /**
  * Disables a suite of specifications.  Used to disable some suites in a file, or files, temporarily during development.
@@ -565,27 +585,35 @@ var describe = function(description, specDefinitions) {
 var xdescribe = function(description, specDefinitions) {
   return jasmine.getEnv().xdescribe(description, specDefinitions);
 };
+if (isCommonJS) exports.xdescribe = xdescribe;
 
 
 // Provide the XMLHttpRequest class for IE 5.x-6.x:
 jasmine.XmlHttpRequest = (typeof XMLHttpRequest == "undefined") ? function() {
-  try {
+  function tryIt(f) {
+    try {
+      return f();
+    } catch(e) {
+    }
+    return null;
+  }
+
+  var xhr = tryIt(function() {
     return new ActiveXObject("Msxml2.XMLHTTP.6.0");
-  } catch(e) {
-  }
-  try {
-    return new ActiveXObject("Msxml2.XMLHTTP.3.0");
-  } catch(e) {
-  }
-  try {
-    return new ActiveXObject("Msxml2.XMLHTTP");
-  } catch(e) {
-  }
-  try {
-    return new ActiveXObject("Microsoft.XMLHTTP");
-  } catch(e) {
-  }
-  throw new Error("This browser does not support XMLHttpRequest.");
+  }) ||
+    tryIt(function() {
+      return new ActiveXObject("Msxml2.XMLHTTP.3.0");
+    }) ||
+    tryIt(function() {
+      return new ActiveXObject("Msxml2.XMLHTTP");
+    }) ||
+    tryIt(function() {
+      return new ActiveXObject("Microsoft.XMLHTTP");
+    });
+
+  if (!xhr) throw new Error("This browser does not support XMLHttpRequest.");
+
+  return xhr;
 } : XMLHttpRequest;
 /**
  * @namespace
@@ -606,7 +634,7 @@ jasmine.util.inherit = function(childClass, parentClass) {
   var subclass = function() {
   };
   subclass.prototype = parentClass.prototype;
-  childClass.prototype = new subclass;
+  childClass.prototype = new subclass();
 };
 
 jasmine.util.formatException = function(e) {
@@ -707,12 +735,17 @@ jasmine.Env.prototype.version = function () {
  * @returns string containing jasmine version build info, if set.
  */
 jasmine.Env.prototype.versionString = function() {
-  if (jasmine.version_) {
-    var version = this.version();
-    return version.major + "." + version.minor + "." + version.build + " revision " + version.revision;
-  } else {
+  if (!jasmine.version_) {
     return "version unknown";
   }
+
+  var version = this.version();
+  var versionString = version.major + "." + version.minor + "." + version.build;
+  if (version.release_candidate) {
+    versionString += ".rc" + version.release_candidate;
+  }
+  versionString += " revision " + version.revision;
+  return versionString;
 };
 
 /**
@@ -760,13 +793,13 @@ jasmine.Env.prototype.describe = function(description, specDefinitions) {
     declarationError = e;
   }
 
-  this.currentSuite = parentSuite;
-
   if (declarationError) {
     this.it("encountered a declaration exception", function() {
       throw declarationError;
     });
   }
+
+  this.currentSuite = parentSuite;
 
   return suite;
 };
@@ -828,7 +861,7 @@ jasmine.Env.prototype.compareObjects_ = function(a, b, mismatchKeys, mismatchVal
   b.__Jasmine_been_here_before__ = a;
 
   var hasKey = function(obj, keyName) {
-    return obj != null && obj[keyName] !== jasmine.undefined;
+    return obj !== null && obj[keyName] !== jasmine.undefined;
   };
 
   for (var property in b) {
@@ -854,7 +887,7 @@ jasmine.Env.prototype.compareObjects_ = function(a, b, mismatchKeys, mismatchVal
 
   delete a.__Jasmine_been_here_before__;
   delete b.__Jasmine_been_here_before__;
-  return (mismatchKeys.length == 0 && mismatchValues.length == 0);
+  return (mismatchKeys.length === 0 && mismatchValues.length === 0);
 };
 
 jasmine.Env.prototype.equals_ = function(a, b, mismatchKeys, mismatchValues) {
@@ -1302,16 +1335,16 @@ jasmine.Matchers.prototype.toHaveBeenCalledWith = function() {
     throw new Error('Expected a spy, but got ' + jasmine.pp(this.actual) + '.');
   }
   this.message = function() {
-    if (this.actual.callCount == 0) {
+    if (this.actual.callCount === 0) {
       // todo: what should the failure message for .not.toHaveBeenCalledWith() be? is this right? test better. [xw]
       return [
-        "Expected spy to have been called with " + jasmine.pp(expectedArgs) + " but it was never called.",
-        "Expected spy not to have been called with " + jasmine.pp(expectedArgs) + " but it was."
+        "Expected spy " + this.actual.identity + " to have been called with " + jasmine.pp(expectedArgs) + " but it was never called.",
+        "Expected spy " + this.actual.identity + " not to have been called with " + jasmine.pp(expectedArgs) + " but it was."
       ];
     } else {
       return [
-        "Expected spy to have been called with " + jasmine.pp(expectedArgs) + " but was called with " + jasmine.pp(this.actual.argsForCall),
-        "Expected spy not to have been called with " + jasmine.pp(expectedArgs) + " but was called with " + jasmine.pp(this.actual.argsForCall)
+        "Expected spy " + this.actual.identity + " to have been called with " + jasmine.pp(expectedArgs) + " but was called with " + jasmine.pp(this.actual.argsForCall),
+        "Expected spy " + this.actual.identity + " not to have been called with " + jasmine.pp(expectedArgs) + " but was called with " + jasmine.pp(this.actual.argsForCall)
       ];
     }
   };
@@ -1333,7 +1366,7 @@ jasmine.Matchers.prototype.wasNotCalledWith = function() {
     return [
       "Expected spy not to have been called with " + jasmine.pp(expectedArgs) + " but it was",
       "Expected spy to have been called with " + jasmine.pp(expectedArgs) + " but it was"
-    ]
+    ];
   };
 
   return !this.env.contains_(this.actual.argsForCall, expectedArgs);
@@ -1367,6 +1400,23 @@ jasmine.Matchers.prototype.toBeGreaterThan = function(expected) {
 };
 
 /**
+ * Matcher that checks that the expected item is equal to the actual item
+ * up to a given level of decimal precision (default 2).
+ *
+ * @param {Number} expected
+ * @param {Number} precision
+ */
+jasmine.Matchers.prototype.toBeCloseTo = function(expected, precision) {
+  if (!(precision === 0)) {
+    precision = precision || 2;
+  }
+  var multiplier = Math.pow(10, precision);
+  var actual = Math.round(this.actual * multiplier);
+  expected = Math.round(expected * multiplier);
+  return expected == actual;
+};
+
+/**
  * Matcher that checks that the expected exception was thrown by the actual.
  *
  * @param {String} expected
@@ -1390,7 +1440,7 @@ jasmine.Matchers.prototype.toThrow = function(expected) {
 
   this.message = function() {
     if (exception && (expected === jasmine.undefined || !this.env.equals_(exception.message || exception, expected.message || expected))) {
-      return ["Expected function " + not + "to throw", expected ? expected.message || expected : " an exception", ", but it threw", exception.message || exception].join(' ');
+      return ["Expected function " + not + "to throw", expected ? expected.message || expected : "an exception", ", but it threw", exception.message || exception].join(' ');
     } else {
       return "Expected function to throw an exception.";
     }
@@ -1602,7 +1652,8 @@ jasmine.PrettyPrinter.prototype.format = function(value) {
 jasmine.PrettyPrinter.prototype.iterateObject = function(obj, fn) {
   for (var property in obj) {
     if (property == '__Jasmine_been_here_before__') continue;
-    fn(property, obj.__lookupGetter__ ? (obj.__lookupGetter__(property) != null) : false);
+    fn(property, obj.__lookupGetter__ ? (obj.__lookupGetter__(property) !== jasmine.undefined && 
+                                         obj.__lookupGetter__(property) !== null) : false);
   }
 };
 
@@ -1962,7 +2013,8 @@ jasmine.Spec.prototype.waitsFor = function(latchFunction, optional_timeoutMessag
 jasmine.Spec.prototype.fail = function (e) {
   var expectationResult = new jasmine.ExpectationResult({
     passed: false,
-    message: e ? jasmine.util.formatException(e) : 'Exception'
+    message: e ? jasmine.util.formatException(e) : 'Exception',
+    trace: { stack: e.stack }
   });
   this.results_.addResult(expectationResult);
 };
@@ -2172,7 +2224,9 @@ jasmine.WaitsBlock = function(env, timeout, spec) {
 jasmine.util.inherit(jasmine.WaitsBlock, jasmine.Block);
 
 jasmine.WaitsBlock.prototype.execute = function (onComplete) {
-  this.env.reporter.log('>> Jasmine waiting for ' + this.timeout + ' ms...');
+  if (jasmine.VERBOSE) {
+    this.env.reporter.log('>> Jasmine waiting for ' + this.timeout + ' ms...');
+  }
   this.env.setTimeout(function () {
     onComplete();
   }, this.timeout);
@@ -2200,7 +2254,9 @@ jasmine.util.inherit(jasmine.WaitsForBlock, jasmine.Block);
 jasmine.WaitsForBlock.TIMEOUT_INCREMENT = 10;
 
 jasmine.WaitsForBlock.prototype.execute = function(onComplete) {
-  this.env.reporter.log('>> Jasmine waiting for ' + (this.message || 'something to happen'));
+  if (jasmine.VERBOSE) {
+    this.env.reporter.log('>> Jasmine waiting for ' + (this.message || 'something to happen'));
+  }
   var latchFunctionResult;
   try {
     latchFunctionResult = this.latchFunction.apply(this.spec);
@@ -2412,10 +2468,9 @@ jasmine.getGlobal().clearInterval = function(timeoutKey) {
   }
 };
 
-
 jasmine.version_= {
   "major": 1,
-  "minor": 0,
-  "build": 2,
-  "revision": 1298837858
+  "minor": 1,
+  "build": 0,
+  "revision": 1315677058
 };

--- a/src/test/resources/examples/jasmine-webapp-10-failing/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-10-failing/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.searls</groupId>
 		<artifactId>jasmine-example-superpom</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>jasmine-webapp-10-failing</artifactId>
 	<packaging>war</packaging>

--- a/src/test/resources/examples/jasmine-webapp-basic-excludes/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-basic-excludes/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.searls</groupId>
 		<artifactId>jasmine-example-superpom</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>jasmine-webapp-basic-excludes</artifactId>
 	<packaging>war</packaging>

--- a/src/test/resources/examples/jasmine-webapp-basic-includes/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-basic-includes/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.searls</groupId>
 		<artifactId>jasmine-example-superpom</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>jasmine-webapp-basic-excludes</artifactId>
 	<packaging>war</packaging>

--- a/src/test/resources/examples/jasmine-webapp-coffee/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-coffee/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.searls</groupId>
 		<artifactId>jasmine-example-superpom</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>jasmine-webapp-coffee</artifactId>
 	<packaging>war</packaging>

--- a/src/test/resources/examples/jasmine-webapp-copy-non-js/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-copy-non-js/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.github.searls</groupId>
     <artifactId>jasmine-example-superpom</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>jasmine-webapp-copy-non-js</artifactId>
   <packaging>war</packaging>

--- a/src/test/resources/examples/jasmine-webapp-custom-browser/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-custom-browser/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.searls</groupId>
 		<artifactId>jasmine-example-superpom</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>jasmine-webapp-custom-browser</artifactId>
 	<packaging>war</packaging>

--- a/src/test/resources/examples/jasmine-webapp-custom-dirs/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-custom-dirs/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.searls</groupId>
 		<artifactId>jasmine-example-superpom</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>jasmine-webapp-custom-dirs</artifactId>
 	<packaging>war</packaging>

--- a/src/test/resources/examples/jasmine-webapp-custom-encoding/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-custom-encoding/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.searls</groupId>
 		<artifactId>jasmine-example-superpom</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>jasmine-webapp-custom-encoding</artifactId>
 	<packaging>war</packaging>

--- a/src/test/resources/examples/jasmine-webapp-custom-runner-missing/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-custom-runner-missing/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.searls</groupId>
 		<artifactId>jasmine-example-superpom</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>jasmine-webapp-custom-runner-missing</artifactId>
 	<packaging>war</packaging>

--- a/src/test/resources/examples/jasmine-webapp-custom-runner/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-custom-runner/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.searls</groupId>
 		<artifactId>jasmine-example-superpom</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>jasmine-webapp-custom-runner</artifactId>
 	<packaging>war</packaging>

--- a/src/test/resources/examples/jasmine-webapp-empty-example/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-empty-example/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.searls</groupId>
 		<artifactId>jasmine-example-superpom</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>jasmine-webapp-empty-example</artifactId>
 	<packaging>war</packaging>

--- a/src/test/resources/examples/jasmine-webapp-load-remote/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-load-remote/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.searls</groupId>
 		<artifactId>jasmine-example-superpom</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>jasmine-webapp-load-remote</artifactId>
 	<packaging>war</packaging>

--- a/src/test/resources/examples/jasmine-webapp-many-failing/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-many-failing/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.searls</groupId>
 		<artifactId>jasmine-example-superpom</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>jasmine-webapp-many-failing</artifactId>
 	<packaging>war</packaging>

--- a/src/test/resources/examples/jasmine-webapp-order-matters/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-order-matters/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.searls</groupId>
 		<artifactId>jasmine-example-superpom</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>jasmine-webapp-order-matters</artifactId>
 	<packaging>war</packaging>

--- a/src/test/resources/examples/jasmine-webapp-passing/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-passing/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.searls</groupId>
 		<artifactId>jasmine-example-superpom</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>jasmine-webapp-passing</artifactId>
 	<packaging>war</packaging>

--- a/src/test/resources/examples/jasmine-webapp-progress-format/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-progress-format/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.searls</groupId>
 		<artifactId>jasmine-example-superpom</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>jasmine-webapp-progress-format</artifactId>
 	<packaging>war</packaging>

--- a/src/test/resources/examples/jasmine-webapp-single-failing/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-single-failing/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.searls</groupId>
 		<artifactId>jasmine-example-superpom</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>jasmine-webapp-single-failing</artifactId>
 	<packaging>war</packaging>

--- a/src/test/resources/examples/jasmine-webapp-spec-order-matters/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-spec-order-matters/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.searls</groupId>
 		<artifactId>jasmine-example-superpom</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>jasmine-webapp-spec-order-matters</artifactId>
 	<packaging>war</packaging>

--- a/src/test/resources/examples/pom.xml
+++ b/src/test/resources/examples/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.searls</groupId>
 	<artifactId>jasmine-example-superpom</artifactId>
-	<version>1.0.2-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>jasmine-maven-plugin Example Projects</name>
 	<build>


### PR DESCRIPTION
I propose an upgrade to Jasmine 1.1.0.

@searls : I am not certain what needs to be updated in `src/test`. All of the java tests pass, but I presume some of the examples should be updated, and perhaps the copy of `jasmine-jquery.js`. There are more files there than I can flip through right now. Do you know which ones should change?
