### PR TITLE
multibyte characters is garbled in the report. (coffeescript only)

### DIFF
--- a/src/main/java/com/github/searls/jasmine/coffee/HandlesRequestsForCoffee.java
+++ b/src/main/java/com/github/searls/jasmine/coffee/HandlesRequestsForCoffee.java
@@ -1,6 +1,7 @@
 package com.github.searls.jasmine.coffee;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -28,14 +29,22 @@ public class HandlesRequestsForCoffee {
 	}
 
 	private void setHeaders(HttpServletResponse response, Resource resource, String javascript) {
+        response.setCharacterEncoding("UTF-8");
 		response.setContentType("text/javascript");
 		response.setDateHeader(HttpHeaders.LAST_MODIFIED, resource.lastModified());
-		response.setHeader(HttpHeaders.CONTENT_LENGTH,Integer.toString(javascript.length()));
+		try {
+            int contentLength = javascript.getBytes("UTF-8").length;
+            response.setHeader(HttpHeaders.CONTENT_LENGTH,Integer.toString(contentLength));
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(
+                    "The JVM does not support the compiler's default encoding.", e);
+        }
+
 	}
 
 	private String compileCoffee(Resource resource) {
 		try {
-			return coffeeScript.compile(IOUtils.toString(resource.getInputStream()));
+			return coffeeScript.compile(IOUtils.toString(resource.getInputStream(), "UTF-8"));
 		} catch(Exception e) {
 			return buildsJavaScriptToWriteFailureHtml.build("CoffeeScript Error: failed to compile <code>"+resource.getName()+"</code>. <br/>Error message:<br/><br/><code>"+e.getMessage()+"</code>");
 		}

--- a/src/test/java/com/github/searls/jasmine/coffee/HandlesRequestsForCoffeeTest.java
+++ b/src/test/java/com/github/searls/jasmine/coffee/HandlesRequestsForCoffeeTest.java
@@ -56,7 +56,14 @@ public class HandlesRequestsForCoffeeTest {
 		
 		verify(response).setContentType("text/javascript");
 	}
-	
+
+    @Test
+    public void setCharacterEncodingToJavaScript() throws IOException {
+        subject.handle(baseRequest, response, resource);
+        
+        verify(response).setCharacterEncoding("UTF-8");
+    }
+
 	@Test
 	public void setsResourceLastModifiedOnResponseHeader() throws IOException {
 		long expected = 98123l;
@@ -77,6 +84,17 @@ public class HandlesRequestsForCoffeeTest {
 		verify(response.getWriter()).write(expected);
 		verify(response).setHeader(HttpHeaders.CONTENT_LENGTH,Integer.toString(expected.length()));
 	}
+
+	@Test
+    public void whenCoffeeCompilesHasMultiByteThenWriteIt() throws IOException {
+        String expected = "あいうえお.coffee";
+        when(coffeeScript.compile(COFFEE)).thenReturn(expected);
+
+        subject.handle(baseRequest, response, resource);
+        
+        verify(response.getWriter()).write(expected);
+        verify(response).setHeader(HttpHeaders.CONTENT_LENGTH,Integer.toString(expected.getBytes("UTF-8").length));
+    }
 
 	@Test
 	public void whenCoffeeCompilationFailsThenWriteTheErrorOutInItsStead() throws IOException {


### PR DESCRIPTION
Hi. I wrote test code by coffeescript.

For example,

``` javascript
describe "panda", ->
    it "is あいうえお", ->
        expect("sad").toEqual "sad"
```

test result report,

```
is ????????
```
