### PR TITLE
Fix intermittent issue with reporter undefined

### DIFF
--- a/src/main/java/com/github/searls/jasmine/runner/SpecRunnerExecutor.java
+++ b/src/main/java/com/github/searls/jasmine/runner/SpecRunnerExecutor.java
@@ -52,7 +52,7 @@ public class SpecRunnerExecutor {
 	private String buildJunitXmlReport(JavascriptExecutor driver, boolean debug) throws IOException {
 		Object junitReport = driver.executeScript(
 				ioUtilsWrapper.toString(CREATE_JUNIT_XML) + 
-				"return junitXmlReporter.report(reporter,"+debug+");"); 
+				"return junitXmlReporter.report(window.reporter,"+debug+");"); 
 		return junitReport.toString();
 	}
 
@@ -81,7 +81,7 @@ public class SpecRunnerExecutor {
 	}
 
 	private Boolean executionFinished(JavascriptExecutor driver) {
-		return (Boolean) driver.executeScript("return reporter.finished");
+		return (Boolean) driver.executeScript("return (window.reporter === undefined) ? false : window.reporter.finished");
 	}
 	
 }


### PR DESCRIPTION
I was experiencing intermittent but regular failures with my tests, I have a significant amount of scripts being loaded.

It seems that there are times that the SpecRunnerExecutor starts asking whether execution has finished before the reporter has been added to the window global object.
