### PR TITLE
Add possibility to specify proxy to be used by HtmlUnitDriver

### DIFF
--- a/src/main/java/com/github/searls/jasmine/TestMojo.java
+++ b/src/main/java/com/github/searls/jasmine/TestMojo.java
@@ -94,6 +94,15 @@ public class TestMojo extends AbstractJasmineMojo {
 				return client;
 			};
 		};
+		
+		// setup proxy if specified
+		String proxyHost = System.getProperty("http.proxyHost");
+		String proxyPort = System.getProperty("http.proxyPort");
+		if (proxyHost != null && proxyPort != null) {
+			getLog().debug("Setting proxy " + proxyHost + ":" + proxyPort);
+			driver.setProxy(proxyHost, Integer.parseInt(proxyPort));
+		}
+		
 		driver.setJavascriptEnabled(true);
 		return driver;
 	}


### PR DESCRIPTION
closes #80

From now on user can specify proxy for HtmlUnitDriver so &lt;preloadSources&gt; won't fail build in such a case when URLs has been specified in &lt;source&gt; element instead of relative local paths.

Example:

```
mvn test -Dhttp.proxyHost=myproxyhost.com -Dhttp.proxyPort=8000
```
