### PR TITLE
conflict between jasmine-maven-plugin and CoffeeScript plugin for RequireJS

### DIFF
--- a/src/main/java/com/github/searls/jasmine/server/JasmineResourceHandler.java
+++ b/src/main/java/com/github/searls/jasmine/server/JasmineResourceHandler.java
@@ -1,6 +1,5 @@
 package com.github.searls.jasmine.server;
 
-import java.io.File;
 import java.io.IOException;
 
 import javax.servlet.ServletException;
@@ -16,22 +15,16 @@ import com.github.searls.jasmine.CreatesManualRunner;
 import com.github.searls.jasmine.NullLog;
 import com.github.searls.jasmine.coffee.DetectsCoffee;
 import com.github.searls.jasmine.coffee.HandlesRequestsForCoffee;
-import com.github.searls.jasmine.model.ScriptSearch;
-import com.github.searls.jasmine.runner.SpecRunnerHtmlGeneratorFactory;
 
 public class JasmineResourceHandler extends ResourceHandler {
 
 	private DetectsCoffee detectsCoffee = new DetectsCoffee();
 	private HandlesRequestsForCoffee handlesRequestsForCoffee = new HandlesRequestsForCoffee();
 	private CreatesManualRunner createsManualRunner;
-	private ScriptSearch sources;
-	private boolean isRequireJs;
 
 	public JasmineResourceHandler(AbstractJasmineMojo config) {
 		createsManualRunner = new CreatesManualRunner(config);
 		createsManualRunner.setLog(new NullLog());
-		sources = config.getSources();
-		isRequireJs = SpecRunnerHtmlGeneratorFactory.REQUIRE_JS.equals(config.getSpecRunnerTemplate());
 	}
 
 	@Override
@@ -54,27 +47,7 @@ public class JasmineResourceHandler extends ResourceHandler {
 	}
 
 	private boolean weCanHandleIt(Request baseRequest, Resource resource) {
-		if (isRequireJs && isSource(resource)) {
-			// CoffeeScript plugin should be used for translation
-			return false;
-		}
 		return !baseRequest.isHandled() && resource != null && resource.exists();
-	}
-
-	private boolean isSource(Resource resource) {
-		File sourceDirectory = sources.getDirectory();
-		File file;
-		try {
-			file = resource.getFile();
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-		while ((file = file.getParentFile()) != null) {
-			if (file.equals(sourceDirectory)) {
-				return true;
-			}
-		}
-		return false;
 	}
 
 }


### PR DESCRIPTION
Hi, thank you for your cool plugin!
I'm trying to use jasmine-maven-plugin with CoffeeScript and RequireJS. Now I have a trouble and a suggestion to solve it.
## problem

I use CoffeeScript to code. Example:

``` js
// main.js
require(['cs!original.module'], function(m){
  // ...
});
```

``` coffee
# original.module.coffee
define [], () ->
  # ...
```

But ProcessResourcesMojo translated `original.module.coffee` to javascript, so [RequireJS's CoffeeScript plugin](http://requirejs.org/docs/download.html#cs) cannot load it correctly. Error messages like `reserved word "function" on line 1` will be displayed.
## solution

Avoid translation for src if requirejs is used. We don't have to change ProcessTestResourcesMojo because requirejs doesn't load test resources.

Please tell me your solution, or let's discuss about mine. I want to know who uses jasmine-maven-plugin with RequireJS and CoffeeScript, and their solution. Thank you!
