### PR TITLE
Added support to define system properties in the plugin configuration.

### DIFF
--- a/src/main/java/com/github/searls/jasmine/AbstractJasmineMojo.java
+++ b/src/main/java/com/github/searls/jasmine/AbstractJasmineMojo.java
@@ -2,12 +2,15 @@ package com.github.searls.jasmine;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
+import org.openqa.selenium.WebDriver;
 
 import com.github.searls.jasmine.exception.StringifiesStackTraces;
 import com.github.searls.jasmine.io.ScansDirectory;
@@ -201,6 +204,13 @@ public abstract class AbstractJasmineMojo extends AbstractMojo {
    */
   protected int serverPort;
 
+  /** List of properties to register in {@link System#getProperties()}.
+   *
+   * @parameter
+   */
+  @SuppressWarnings("rawtypes")
+  private Map systemProperties = new HashMap();
+
   /**
    * Determines the strategy to use when generation the JasmineSpecRunner. This feature allows for custom
    * implementation of the runner generator. Typically this is used when using different script runners.
@@ -228,7 +238,7 @@ public abstract class AbstractJasmineMojo extends AbstractMojo {
   public final void execute() throws MojoExecutionException, MojoFailureException {
     sources = new ScriptSearch(jsSrcDir,sourceIncludes,sourceExcludes);
     specs = new ScriptSearch(jsTestSrcDir,specIncludes,specExcludes);
-
+    registerSystemProperties();
     try {
       run();
     } catch(MojoFailureException e) {
@@ -285,7 +295,17 @@ public abstract class AbstractJasmineMojo extends AbstractMojo {
 
   }
 
-    public String getScriptLoaderPath() {
-        return scriptLoaderPath;
+  public String getScriptLoaderPath() {
+      return scriptLoaderPath;
+  }
+
+  /** Registers system properties in {@link System#getProperties()} so custom
+   * {@link WebDriver}s are able to get context from the current execution.
+   */
+  private void registerSystemProperties() {
+    for (Object key : systemProperties.keySet()) {
+      System.setProperty(String.valueOf(key),
+          String.valueOf(systemProperties.get(key)));
     }
+  }
 }

--- a/src/test/java/com/github/searls/jasmine/AbstractJasmineMojoTest.java
+++ b/src/test/java/com/github/searls/jasmine/AbstractJasmineMojoTest.java
@@ -6,8 +6,10 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.io.File;
+import java.util.HashMap;
 
 import org.apache.maven.plugin.MojoFailureException;
+import org.codehaus.plexus.util.ReflectionUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -23,6 +25,7 @@ import com.github.searls.jasmine.exception.StringifiesStackTraces;
 public class AbstractJasmineMojoTest {
 
   @InjectMocks @Spy AbstractJasmineMojo subject = new AbstractJasmineMojo() {
+    @Override
     public void run() throws Exception {}
   };
   @Mock private StringifiesStackTraces stringifiesStackTraces = new StringifiesStackTraces();
@@ -79,4 +82,13 @@ public class AbstractJasmineMojoTest {
     assertThat(subject.specs.getExcludes(),is(empty()));
   }
 
+  @Test
+  public void systemProperties() throws Exception {
+    HashMap<String, String> systemProperties = new HashMap<String, String>();
+    systemProperties.put("testProperty", "foo");
+    ReflectionUtils.setVariableValueInObject(subject, "systemProperties",
+        systemProperties);
+    subject.execute();
+    assertThat(System.getProperty("testProperty"), is("foo"));
+  }
 }


### PR DESCRIPTION
Stimulus:
  Custom web drivers need to reference test resources from somewhere. In a multi-module environment children modules are not able to determine the module directory, and it's not possible to load resources from the classpath due maven isolation policies.

Fix proposal:
  Allow modules to configure system properties in the plugin, so they can put, for example, the current execution directory as a system property. It also makes jasmine-maven-plugin more similar tu surefire, which supports this useful feature.

Tech Details:
- Map configured system properties into System#properties collection.
