### PR TITLE
Running individual specs with the REQUIRE_JS specRunnerTemplate.

### DIFF
--- a/src/main/resources/jasmine-templates/RequireJsSpecRunner.htmltemplate
+++ b/src/main/resources/jasmine-templates/RequireJsSpecRunner.htmltemplate
@@ -26,8 +26,13 @@
         });
 
     require(specs, function() {
-      window.reporter = new jasmine.$reporter$(); jasmine.getEnv().addReporter(reporter);
-      jasmine.getEnv().execute();
+      window.reporter = new jasmine.$reporter$();
+      var env = jasmine.getEnv();
+      env.specFilter = function(spec) {
+        return reporter.specFilter(spec);
+      };
+      env.addReporter(reporter);
+      env.execute();
     });
   </script>
 </body>


### PR DESCRIPTION
Here's a pull attempting to make the RequireJsSpecRunner take into account the reporters specfilter, enabling running individual specs when using require.js.

The solution was suggested on the mailing list, and seems to work ok - though I'm not sure this is the desired solution. Comments are appreciated.
