### PR TITLE
Fixed issue #127 very slow running times with HTMLUnit

### DIFF
--- a/src/main/resources/jasmine-templates/RequireJsSpecRunner.htmltemplate
+++ b/src/main/resources/jasmine-templates/RequireJsSpecRunner.htmltemplate
@@ -12,6 +12,11 @@
     if(window.location.href.indexOf("ManualSpecRunner.html") !== -1) {
       document.body.appendChild(document.createTextNode("Warning: opening this HTML file directly from the file system is deprecated. You should instead try running `mvn jasmine:bdd` from the command line, and then visit `http://localhost:8234` in your browser. "))
     }
+    
+    //Don't do live updates when running through HTMLUnit
+    if(typeof Packages !== "undefined"){
+		jasmine.getEnv().updateInterval = Number.MAX_VALUE;
+    }
 
     var specs = $specs$;
 

--- a/src/main/resources/jasmine-templates/SpecRunner.htmltemplate
+++ b/src/main/resources/jasmine-templates/SpecRunner.htmltemplate
@@ -12,6 +12,12 @@
     if(window.location.href.indexOf("ManualSpecRunner.html") !== -1) {
       document.body.appendChild(document.createTextNode("Warning: opening this HTML file directly from the file system is deprecated. You should instead try running `mvn jasmine:bdd` from the command line, and then visit `http://localhost:8234` in your browser. "))
     }
+    
+    //Don't do live updates when running through HTMLUnit
+    if(typeof Packages !== "undefined"){
+		jasmine.getEnv().updateInterval = Number.MAX_VALUE;
+    }
+    
 
     var executeJasmineSpecs = function(){
       window.reporter = new jasmine.$reporter$(); jasmine.getEnv().addReporter(reporter);


### PR DESCRIPTION
This fixes the severe performance issues with big test suites due to unnecessary screen updates and how Rhino handles asynchronous things.
