### PR TITLE
Allows symlinks in the source

### DIFF
--- a/src/main/java/com/github/searls/jasmine/ResourceHandlerConfigurator.java
+++ b/src/main/java/com/github/searls/jasmine/ResourceHandlerConfigurator.java
@@ -25,12 +25,15 @@ public class ResourceHandlerConfigurator {
     ContextHandlerCollection contexts = new ContextHandlerCollection();
 
     ContextHandler srcDirContextHandler = contexts.addContext("/" + configuration.srcDirectoryName, "");
+    srcDirContextHandler.setAliases(true);
     srcDirContextHandler.setHandler(createResourceHandler(true, configuration.sources.getDirectory().getAbsolutePath(), null));
 
     ContextHandler specDirContextHandler = contexts.addContext("/" + configuration.specDirectoryName, "");
+    specDirContextHandler.setAliases(true);
     specDirContextHandler.setHandler(createResourceHandler(true, configuration.specs.getDirectory().getAbsolutePath(), null));
 
     ContextHandler rootContextHandler = contexts.addContext("/", "");
+    rootContextHandler.setAliases(true);
     rootContextHandler.setHandler(createResourceHandler(false, configuration.mavenProject.getBasedir().getAbsolutePath(), new String[]{manualSpecRunnerPath()}));
 
     return contexts;

--- a/src/main/java/com/github/searls/jasmine/server/JasmineResourceHandler.java
+++ b/src/main/java/com/github/searls/jasmine/server/JasmineResourceHandler.java
@@ -25,6 +25,7 @@ public class JasmineResourceHandler extends ResourceHandler {
   public JasmineResourceHandler(AbstractJasmineMojo config) {
     createsManualRunner = new CreatesManualRunner(config);
     createsManualRunner.setLog(new NullLog());
+    setAliases(true);
   }
 
   @Override


### PR DESCRIPTION
This patch enables jasmine-maven-plugin to manage symlinks.

Git supports symlinks, and it is a nice feature in some cases.
