### PR TITLE
Re-fix exponential slowness when running under maven.

### DIFF
--- a/src/main/resources/jasmine-templates/RequireJsSpecRunner.htmltemplate
+++ b/src/main/resources/jasmine-templates/RequireJsSpecRunner.htmltemplate
@@ -13,11 +13,6 @@
       document.body.appendChild(document.createTextNode("Warning: opening this HTML file directly from the file system is deprecated. You should instead try running `mvn jasmine:bdd` from the command line, and then visit `http://localhost:8234` in your browser. "))
     }
     
-    //Don't do live updates when running through HTMLUnit
-    if(typeof Packages !== "undefined"){
-		jasmine.getEnv().updateInterval = Number.MAX_VALUE;
-    }
-
     var specs = $specsList$;
 				
     var configuration = {
@@ -51,6 +46,12 @@
           return window.reporter.specFilter(spec);
         };
       }
+      
+	  //Don't do live updates when running through HTMLUnit
+      if ('$reporter$' == 'JsApiReporter'){
+		jasmine.getEnv().updateInterval = Number.MAX_VALUE;
+      }
+      
       jasmine.getEnv().execute();
     });
   </script>

--- a/src/main/resources/jasmine-templates/SpecRunner.htmltemplate
+++ b/src/main/resources/jasmine-templates/SpecRunner.htmltemplate
@@ -13,11 +13,6 @@
       document.body.appendChild(document.createTextNode("Warning: opening this HTML file directly from the file system is deprecated. You should instead try running `mvn jasmine:bdd` from the command line, and then visit `http://localhost:8234` in your browser. "))
     }
     
-    //Don't do live updates when running through HTMLUnit
-    if(typeof Packages !== "undefined"){
-		jasmine.getEnv().updateInterval = Number.MAX_VALUE;
-    }
-    
 
     var executeJasmineSpecs = function(){
       window.reporter = new jasmine.$reporter$(); jasmine.getEnv().addReporter(reporter);
@@ -26,6 +21,12 @@
           return window.reporter.specFilter(spec);
         };
       }
+      
+	  //Don't do live updates when running through HTMLUnit
+      if ('$reporter$' == 'JsApiReporter'){
+		jasmine.getEnv().updateInterval = Number.MAX_VALUE;
+      }
+      
       jasmine.getEnv().execute();
     };
 


### PR DESCRIPTION
Newest HTMLUnit removed the rhino globals we were using to detect if we were
running under HTMLUnit so things reverted to slow runnning. This will make it
use a long updateInterval when running with the JsApiReporter which should
only be when running the test goal.
