### PR TITLE
Adds support to store third party libraries out of the src directory tree.

### DIFF
--- a/src/main/java/com/github/searls/jasmine/config/JasmineConfiguration.java
+++ b/src/main/java/com/github/searls/jasmine/config/JasmineConfiguration.java
@@ -14,9 +14,11 @@ public interface JasmineConfiguration {
 
   String getSrcDirectoryName();
   String getSpecDirectoryName();
+  String getLibDirectoryName();
 
   ScriptSearch getSources();
   ScriptSearch getSpecs();
+  File getLibsDirectory();
 
   List<String> getPreloadSources();
 

--- a/src/main/java/com/github/searls/jasmine/mojo/AbstractJasmineMojo.java
+++ b/src/main/java/com/github/searls/jasmine/mojo/AbstractJasmineMojo.java
@@ -41,6 +41,11 @@ public abstract class AbstractJasmineMojo extends AbstractMojo implements Jasmin
       defaultValue="${project.basedir}${file.separator}src${file.separator}test${file.separator}javascript")
   private File jsTestSrcDir;
 
+  @Parameter(
+    property="jsLibSrcDir",
+    defaultValue="${project.basedir}${file.separator}src${file.separator}main${file.separator}webapp${file.separator}js${file.separator}lib")
+  protected File libsDirectory;
+
   /**
    * Determines the Selenium WebDriver class we'll use to execute the tests. See the Selenium documentation for more details.
    * The plugin uses <a href="http://htmlunit.sourceforge.net/">HtmlUnit</a> by default.
@@ -213,6 +218,14 @@ public abstract class AbstractJasmineMojo extends AbstractMojo implements Jasmin
   protected String srcDirectoryName;
 
   /**
+   * The name of the directory the third party libraries will be deployed to on the server
+   *
+   * @since 1.3.1.1
+   */
+  @Parameter(defaultValue="lib")
+  protected String libDirectoryName;
+
+  /**
    * The source encoding.
    * 
    * @since 1.1.0
@@ -379,6 +392,11 @@ public abstract class AbstractJasmineMojo extends AbstractMojo implements Jasmin
   }
 
   @Override
+  public String getLibDirectoryName() {
+    return this.libDirectoryName;
+  }
+
+  @Override
   public ScriptSearch getSources() {
     return this.sources;
   }
@@ -386,6 +404,11 @@ public abstract class AbstractJasmineMojo extends AbstractMojo implements Jasmin
   @Override
   public ScriptSearch getSpecs() {
     return this.specs;
+  }
+
+  @Override
+  public File getLibsDirectory() {
+    return this.libsDirectory;
   }
 
   @Override

--- a/src/main/java/com/github/searls/jasmine/mojo/ServerMojo.java
+++ b/src/main/java/com/github/searls/jasmine/mojo/ServerMojo.java
@@ -23,7 +23,8 @@ public class ServerMojo extends AbstractJasmineMojo {
           "\n\n" +
           "The server will monitor these two directories for scripts that you add, remove, and change:\n\n" +
           "  source directory: %s\n\n"+
-          "  spec directory: %s"+
+          "  spec directory: %s\n\n"+
+          "  lib directory: %s"+
           "\n\n"+
           "Just leave this process running as you test-drive your code, refreshing your browser window to re-run your specs. You can kill the server with Ctrl-C when you're done.";
 
@@ -38,7 +39,8 @@ public class ServerMojo extends AbstractJasmineMojo {
         INSTRUCTION_FORMAT,
         this.serverPort,
         this.getRelativePath(this.sources.getDirectory()),
-        this.getRelativePath(this.specs.getDirectory()));
+        this.getRelativePath(this.specs.getDirectory()),
+        this.getRelativePath(this.getLibsDirectory()));
   }
 
   @Override

--- a/src/main/java/com/github/searls/jasmine/server/ResourceHandlerConfigurator.java
+++ b/src/main/java/com/github/searls/jasmine/server/ResourceHandlerConfigurator.java
@@ -35,6 +35,9 @@ public class ResourceHandlerConfigurator {
     ContextHandler specDirContextHandler = contexts.addContext("/" + this.configuration.getSpecDirectoryName(), "");
     specDirContextHandler.setHandler(this.createResourceHandler(true, this.configuration.getSpecs().getDirectory().getAbsolutePath(), null));
 
+    ContextHandler libDirContextHandler = contexts.addContext("/"+ this.configuration.getLibDirectoryName(), "");
+    libDirContextHandler.setHandler(this.createResourceHandler(true, this.configuration.getLibsDirectory().getAbsolutePath(), null));
+
     ContextHandler rootContextHandler = contexts.addContext("/", "");
     rootContextHandler.setHandler(this.createResourceHandler(false, this.configuration.getBasedir().getAbsolutePath(), new String[]{this.getWelcomeFilePath()}));
 

--- a/src/test/java/com/github/searls/jasmine/mojo/ServerMojoTest.java
+++ b/src/test/java/com/github/searls/jasmine/mojo/ServerMojoTest.java
@@ -29,6 +29,7 @@ public class ServerMojoTest {
 
   private static final String SPECS_DIR = "spec dir";
   private static final String SOURCE_DIR = "source dir";
+  private static final String LIBS_DIR = "lib dir";
   private static final int PORT = 8923;
   private static final String RELATIVE_TARGET_DIR = "some dir";
   private static final String MANUAL_SPEC_RUNNER_NAME = "nacho specs";
@@ -43,8 +44,10 @@ public class ServerMojoTest {
   @Mock private File targetDir;
   @Mock private File sourceDir;
   @Mock private File specDir;
+  @Mock private File libDir;
   @Mock private ScriptSearch sources;
   @Mock private ScriptSearch specs;
+  @Mock private File libs;
   @Mock private ResourceHandlerConfigurator configurator;
   @Mock private ServerManager serverManager;
 
@@ -52,6 +55,7 @@ public class ServerMojoTest {
   public void arrangeAndAct() throws Exception {
     this.subject.sources = this.sources;
     this.subject.specs = this.specs;
+    this.subject.libsDirectory = this.libs;
     this.subject.setLog(this.log);
     this.subject.serverPort = PORT;
     this.subject.jasmineTargetDir = this.targetDir;
@@ -59,13 +63,15 @@ public class ServerMojoTest {
     this.subject.specRunnerTemplate = SpecRunnerTemplate.DEFAULT;
     when(this.sourceDir.getAbsolutePath()).thenReturn(SOURCE_DIR);
     when(this.specDir.getAbsolutePath()).thenReturn(SPECS_DIR);
+    when(this.libDir.getAbsolutePath()).thenReturn(LIBS_DIR);
     when(this.sources.getDirectory()).thenReturn(this.sourceDir);
     when(this.specs.getDirectory()).thenReturn(this.specDir);
     when(this.baseDir.getAbsolutePath()).thenReturn(BASE_DIR);
     when(this.mavenProject.getBasedir()).thenReturn(this.baseDir);
-    when(this.relativizesFilePaths.relativize(this.baseDir,this.targetDir)).thenReturn(RELATIVE_TARGET_DIR);
+    when(this.relativizesFilePaths.relativize(this.baseDir, this.targetDir)).thenReturn(RELATIVE_TARGET_DIR);
     when(this.relativizesFilePaths.relativize(this.baseDir,this.sources.getDirectory())).thenReturn(SOURCE_DIR);
     when(this.relativizesFilePaths.relativize(this.baseDir,this.specs.getDirectory())).thenReturn(SPECS_DIR);
+    when(this.relativizesFilePaths.relativize(this.baseDir,this.libs)).thenReturn(LIBS_DIR);
 
     whenNew(ResourceHandlerConfigurator.class).withArguments(
         this.subject,
@@ -80,7 +86,7 @@ public class ServerMojoTest {
 
   @Test
   public void logsInstructions() {
-    verify(this.log).info(String.format(ServerMojo.INSTRUCTION_FORMAT, PORT, SOURCE_DIR, SPECS_DIR));
+    verify(this.log).info(String.format(ServerMojo.INSTRUCTION_FORMAT, PORT, SOURCE_DIR, SPECS_DIR, LIBS_DIR));
   }
 
   @Test

--- a/src/test/java/com/github/searls/jasmine/server/ResourceHandlerConfiguratorTest.java
+++ b/src/test/java/com/github/searls/jasmine/server/ResourceHandlerConfiguratorTest.java
@@ -23,6 +23,7 @@ public class ResourceHandlerConfiguratorTest {
   private static final String SOURCE_DIRECTORY = "sourcedir";
   private static final String SPEC_DIRECTORY = "specdir";
   private static final String BASE_DIRECTORY = "basedir";
+  private static final String LIB_DIRECTORY = "libdir";
 
   private ResourceHandlerConfigurator configurator;
 
@@ -40,6 +41,9 @@ public class ResourceHandlerConfiguratorTest {
 
   @Mock
   private File baseDirectory;
+
+  @Mock
+  private File libDirectory;
 
   @Mock
   private ScriptSearch sources;
@@ -61,12 +65,14 @@ public class ResourceHandlerConfiguratorTest {
     when(sourceDirectory.getAbsolutePath()).thenReturn(SOURCE_DIRECTORY);
     when(specDirectory.getAbsolutePath()).thenReturn(SPEC_DIRECTORY);
     when(baseDirectory.getAbsolutePath()).thenReturn(BASE_DIRECTORY);
+    when(libDirectory.getAbsolutePath()).thenReturn(LIB_DIRECTORY);
 
     when(sources.getDirectory()).thenReturn(sourceDirectory);
     when(specs.getDirectory()).thenReturn(specDirectory);
 
     when(configuration.getSpecs()).thenReturn(specs);
     when(configuration.getSources()).thenReturn(sources);
+    when(configuration.getLibsDirectory()).thenReturn(libDirectory);
     when(configuration.getBasedir()).thenReturn(baseDirectory);
 
     this.configurator.createHandler();


### PR DESCRIPTION
I try to keep my javascript code separate from third party libraries. Something like

```
src
    main/js
       myJavascript.js
        ...
    webapp/js/lib
        jquery.js
        ....
    test/js
         myJavascriptSpec.js
```

So I need for those libraries to be available during unit testing. I've modified the pluging to enable serving the files in the path _jsLibSrcDir_ under the _libDirectoryName_ path.

The above directory layout will match this configuration:

``` xml
        <configuration>
          <jsSrcDir>src/main/js</jsSrcDir>
          <jsTestSrcDir>src/test/js</jsTestSrcDir>
          <jsLibSrcDir>src/main/js/lib</jsLibSrcDir>
          <libDirectoryName>js/lib</libDirectoryName>
```
