### PR TITLE
adding option for a poor man's CI, closes #5

### DIFF
--- a/features/autorefresh.feature
+++ b/features/autorefresh.feature
@@ -1,0 +1,27 @@
+Feature: auto refresh the test runner
+
+  In order to have constant test feedback as I modify my code.
+  I want to be able to set the test runner to refresh at an interval I choose.
+  
+  @server
+  Scenario: default settings should not auto refresh
+
+    Given I am currently in the "jasmine-webapp-passing" project
+    When I run "mvn clean jasmine:bdd" in a new process
+    And I load "http://localhost:8234" in a browser
+    Then the file "target/jasmine/ManualSpecRunner.html" should not contain "<meta http-equiv=\"refresh\""
+  
+  @server
+  Scenario: auto refresh every 5 seconds
+
+    Given I am currently in the "jasmine-webapp-passing" project
+    When I run "mvn clean jasmine:bdd -Djasmine.autoRefreshInterval=5" in a new process
+    And I load "http://localhost:8234" in a browser
+    Then the file "target/jasmine/ManualSpecRunner.html" should contain "<meta http-equiv=\"refresh\" content=\"5\">"
+
+  Scenario: auto refresh should not apply to jasmine:test goal
+
+    Given I am currently in the "jasmine-webapp-passing" project
+    When I run "mvn clean test -Djasmine.autoRefreshInterval=5"
+    Then the build should succeed
+    And the file "target/jasmine/SpecRunner.html" should not contain "<meta http-equiv=\"refresh\""

--- a/features/step_definitions/mvn_steps.rb
+++ b/features/step_definitions/mvn_steps.rb
@@ -27,6 +27,10 @@ Then /^the file "([^"]*)" should contain "(.*)"$/ do |file_name,content|
   load_file(file_name).should match content
 end
 
+Then /^the file "([^"]*)" should not contain "(.*)"$/ do |file_name,content|
+  load_file(file_name).should_not match content
+end
+
 Then /^the file "([^"]*)" should have XML "(.*)"$/ do |file_name, xpath|
   Nokogiri::XML.parse(load_file(file_name)).xpath(xpath).length.should be >= 1
 end

--- a/src/main/java/com/github/searls/jasmine/config/JasmineConfiguration.java
+++ b/src/main/java/com/github/searls/jasmine/config/JasmineConfiguration.java
@@ -30,4 +30,6 @@ public interface JasmineConfiguration {
   File getCustomRunnerConfiguration();
 
   String getScriptLoaderPath();
+
+  int getAutoRefreshInterval();
 }

--- a/src/main/java/com/github/searls/jasmine/mojo/AbstractJasmineMojo.java
+++ b/src/main/java/com/github/searls/jasmine/mojo/AbstractJasmineMojo.java
@@ -326,8 +326,16 @@ public abstract class AbstractJasmineMojo extends AbstractMojo implements Jasmin
   @Deprecated
   protected String scriptLoaderPath;
 
-  @Parameter(defaultValue="${project}", readonly=true)
+  /**
+   * <p>Automatically refresh the test runner at the given interval (specified in seconds) when using the <code>jasmine:bdd</code> goal.</p>
+   * <p>A value of <code>0</code> disables the automatic refresh (which is the default).</p>
+   * 
+   * @since 1.3.1.1
+   */
+  @Parameter(property="jasmine.autoRefreshInterval", defaultValue="0")
+  protected int autoRefreshInterval;
 
+  @Parameter(defaultValue="${project}", readonly=true)
   protected MavenProject mavenProject;
 
   protected ScriptSearch sources;
@@ -411,6 +419,11 @@ public abstract class AbstractJasmineMojo extends AbstractMojo implements Jasmin
         this.preloadSources.add(requireJsPath);
       }
     }
+  }
+
+  @Override
+  public int getAutoRefreshInterval() {
+    return this.autoRefreshInterval;
   }
 
   public MavenProject getMavenProject() {

--- a/src/main/java/com/github/searls/jasmine/runner/DefaultSpecRunnerHtmlGenerator.java
+++ b/src/main/java/com/github/searls/jasmine/runner/DefaultSpecRunnerHtmlGenerator.java
@@ -56,6 +56,9 @@ public class DefaultSpecRunnerHtmlGenerator extends AbstractSpecRunnerHtmlGenera
     template.add("sourceDir", sourceDirectory);
     template.add("specDir", specDirectory);
 
+    template.add("autoRefresh", this.getConfiguration().getAutoRefresh());
+    template.add("autoRefreshInterval", this.getConfiguration().getAutoRefreshInterval());
+
     this.setCustomRunnerConfig(template);
     template.add(REPORTER_ATTR_NAME, this.getConfiguration().getReporterType().name());
     this.setEncoding(this.getConfiguration(), template);

--- a/src/main/java/com/github/searls/jasmine/runner/HtmlGeneratorConfiguration.java
+++ b/src/main/java/com/github/searls/jasmine/runner/HtmlGeneratorConfiguration.java
@@ -20,6 +20,8 @@ public class HtmlGeneratorConfiguration {
   private final File customRunnerConfiguration;
   private final String srcDirectoryName;
   private final String specDirectoryName;
+  private final int autoRefreshInterval;
+  private final boolean autoRefresh;
 
   public HtmlGeneratorConfiguration(ReporterType reporterType, JasmineConfiguration configuration, ScriptResolver scriptResolver) throws IOException {
     this.sourceEncoding = configuration.getSourceEncoding();
@@ -32,6 +34,8 @@ public class HtmlGeneratorConfiguration {
     this.scriptLoaderPath = configuration.getScriptLoaderPath();
     this.srcDirectoryName = configuration.getSrcDirectoryName();
     this.specDirectoryName = configuration.getSpecDirectoryName();
+    this.autoRefreshInterval = configuration.getAutoRefreshInterval();
+    this.autoRefresh = this.autoRefreshInterval > 0 && ReporterType.HtmlReporter.equals(reporterType);
   }
 
   public String getSourceEncoding() {
@@ -124,6 +128,14 @@ public class HtmlGeneratorConfiguration {
 
   public String getSpecDirectoryName() {
     return this.specDirectoryName;
+  }
+
+  public int getAutoRefreshInterval() {
+    return this.autoRefreshInterval;
+  }
+
+  public boolean getAutoRefresh() {
+    return this.autoRefresh;
   }
 }
 

--- a/src/main/resources/jasmine-templates/RequireJsSpecRunner.htmltemplate
+++ b/src/main/resources/jasmine-templates/RequireJsSpecRunner.htmltemplate
@@ -2,6 +2,9 @@
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=$sourceEncoding$">
+  $if(autoRefresh)$
+  <meta http-equiv="refresh" content="$autoRefreshInterval$">
+  $endif$
   <title>Jasmine Spec Runner</title>
   $cssDependencies$
   $javascriptDependencies$

--- a/src/main/resources/jasmine-templates/SpecRunner.htmltemplate
+++ b/src/main/resources/jasmine-templates/SpecRunner.htmltemplate
@@ -2,6 +2,9 @@
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=$sourceEncoding$">
+  $if(autoRefresh)$
+  <meta http-equiv="refresh" content="$autoRefreshInterval$">
+  $endif$
   <title>Jasmine Spec Runner</title>
   $cssDependencies$
   $javascriptDependencies$

--- a/src/site/markdown/spec-runner-templates.md
+++ b/src/site/markdown/spec-runner-templates.md
@@ -30,6 +30,8 @@ The following variables are available for use in your custom template:
  * **sourceDir** : the path to the sources when deployed to the jetty server. Should be the same as the `srcDirectoryName` parameter.
  * **specDir** : the path to the specs when deployed to the jetty server. Should be the same as the `specDirectoryName` parameter.
  * **customRunnerConfiguration** : this renders the contents of the file specified by the `customRunnerConfiguration` parameter. Use this is you want to provide a way for adding some external customization to you template. It is most likely not that useful though if you are already writing a custom template.
+ * **autoRefresh** : this is a boolean indicating whether or not the page should be refreshed automatically at an interval. It will be true with the `autoRefreshInterval` plugin parameter is greater than 0 and the `jasmine:bdd` goal is being used.
+ * **autoRefreshInterval** : the interval at which the page should be automatically refreshed. Should be the same as the `autoRefreshInterval` parameter.
 
 These variables were used in older versions of the plugin and have been kept for backwards compatibility. They should be considered deprecated and will be removed in a later version of the plugin.
 

--- a/src/test/java/com/github/searls/jasmine/mojo/AbstractJasmineMojoTest.java
+++ b/src/test/java/com/github/searls/jasmine/mojo/AbstractJasmineMojoTest.java
@@ -146,4 +146,10 @@ public class AbstractJasmineMojoTest {
   public void testGetMavenProject() {
     assertThat(subject.getMavenProject(), is(mavenProject));
   }
+
+  @Test
+  public void testGetAutoRefreshInterval() {
+    subject.autoRefreshInterval = 5;
+    assertThat(subject.getAutoRefreshInterval(), is(5));
+  }
 }


### PR DESCRIPTION
Adds a new configuration parameter `autoRefreshInterval`.  The default value of the parameter is `0` which means that the test runner should not auto refresh.  If the parameter is set to a positive number then the test runner will automatically refresh at that interval (in seconds).  The parameter only applies to the `jasmine:bdd` goal and will be ignored by the `jasmine:test` goal.

Example config with auto refresh set to every 5 seconds:

``` xml
<plugin>
    <groupId>com.github.searls</groupId>
    <artifactId>jasmine-maven-plugin</artifactId>
    <version>${jasmine-maven-plugin.version}</version>
    <configuration>
        <autoRefreshInterval>5</autoRefreshInterval>
    </configuration>
</plugin>
```

You can also set the refresh interval by command line which might be more useful:

```
mvn jasmine:bdd -Djasmine.autoRefreshInterval=5
```
