### PR TITLE
1.3.1.1 fails to run FirefoxDriver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
   <properties>
     <powermock.version>1.4.12</powermock.version>
     <jetty.version>8.1.10.v20130312</jetty.version>
+    <selenium.version>2.32.0</selenium.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -149,7 +150,23 @@
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
-      <version>2.31.0</version>
+      <version>${selenium.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.seleniumhq.selenium</groupId>
+      <artifactId>selenium-server</artifactId>
+      <version>${selenium.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>servlet-api-2.5</artifactId>
+          <groupId>org.mortbay.jetty</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.seleniumhq.selenium</groupId>
+      <artifactId>selenium-remote-driver</artifactId>
+      <version>${selenium.version}</version>
     </dependency>
     <dependency>
       <groupId>org.antlr</groupId>
@@ -170,11 +187,6 @@
       <groupId>backport-util-concurrent</groupId>
       <artifactId>backport-util-concurrent</artifactId>
       <version>3.1</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.5</version>
     </dependency>
     <dependency>
       <groupId>com.github.detro.ghostdriver</groupId>

--- a/src/test/resources/examples/jasmine-webapp-firefox/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-firefox/pom.xml
@@ -1,0 +1,32 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.github.searls</groupId>
+    <artifactId>jasmine-example-superpom</artifactId>
+    <version>%{project.version}</version>
+  </parent>
+  <artifactId>jasmine-webapp-passing</artifactId>
+  <packaging>war</packaging>
+  <name>Example Webapp using Jasmine Maven Plugin</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.searls</groupId>
+        <artifactId>jasmine-maven-plugin</artifactId>
+        <version>%{project.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <webDriverClassName>org.openqa.selenium.firefox.FirefoxDriver</webDriverClassName>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/examples/jasmine-webapp-firefox/src/main/javascript/HelloWorld.js
+++ b/src/test/resources/examples/jasmine-webapp-firefox/src/main/javascript/HelloWorld.js
@@ -1,0 +1,5 @@
+var HelloWorld = function() {
+  this.greeting = function() {
+    return "Hello, World";
+  }
+}

--- a/src/test/resources/examples/jasmine-webapp-firefox/src/test/javascript/HelloWorldSpec.js
+++ b/src/test/resources/examples/jasmine-webapp-firefox/src/test/javascript/HelloWorldSpec.js
@@ -1,0 +1,8 @@
+describe('HelloWorld',function(){
+
+  it('should say hello',function(){
+    var helloWorld = new HelloWorld();
+    expect(helloWorld.greeting()).toBe("Hello, World");
+  });
+
+});


### PR DESCRIPTION
when I run 1.3.1.1 with a configuration of &lt;webDriverClassName>org.openqa.selenium.firefox.FirefoxDriver&lt;/webDriverClassName> it breaks with the following exception. I found https://code.google.com/p/selenium/issues/detail?id=5470 discussing a similar stacktrace but I was unable to resolve it by adding selenium 2.32 as the dependency of jasmine-maven-plugin using this code:

``` xml
            <plugin>
                <groupId>com.github.searls</groupId>
                <artifactId>jasmine-maven-plugin</artifactId>
                <version>1.3.1.1</version>
                <!-- ... SNIP... -->
                <dependencies>
                    <dependency>
                        <groupId>org.seleniumhq.selenium</groupId>
                        <artifactId>selenium-java</artifactId>
                        <version>2.32.0</version>
                    </dependency>
                </dependencies>
            </plugin>
```

This is the error printed by maven when running install or jasmine:test

```
[ERROR] Failed to execute goal com.github.searls:jasmine-maven-plugin:1.3.1.1:test (default) on project myproject: The jasmine-maven-plugin encountered an exception:
    [ERROR] java.lang.reflect.InvocationTargetException
    [ERROR] at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    [ERROR] at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
    [ERROR] at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    [ERROR] at java.lang.reflect.Constructor.newInstance(Constructor.java:525)
    [ERROR] at com.github.searls.jasmine.driver.WebDriverFactory.createCustomWebDriver(WebDriverFactory.java:67)
    [ERROR] at com.github.searls.jasmine.driver.WebDriverFactory.createWebDriver(WebDriverFactory.java:47)
    [ERROR] at com.github.searls.jasmine.mojo.TestMojo.createDriver(TestMojo.java:92)
    [ERROR] at com.github.searls.jasmine.mojo.TestMojo.executeSpecs(TestMojo.java:77)
    [ERROR] at com.github.searls.jasmine.mojo.TestMojo.run(TestMojo.java:43)
    [ERROR] at com.github.searls.jasmine.mojo.AbstractJasmineMojo.execute(AbstractJasmineMojo.java:387)
    [ERROR] at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:101)
    [ERROR] at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:209)
    [ERROR] at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
    [ERROR] at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
    [ERROR] at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
    [ERROR] at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
    [ERROR] at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
    [ERROR] at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
    [ERROR] at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:319)
    [ERROR] at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:156)
    [ERROR] at org.apache.maven.cli.MavenCli.execute(MavenCli.java:537)
    [ERROR] at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:196)
    [ERROR] at org.apache.maven.cli.MavenCli.main(MavenCli.java:141)
    [ERROR] at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    [ERROR] at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    [ERROR] at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    [ERROR] at java.lang.reflect.Method.invoke(Method.java:601)
    [ERROR] at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:290)
    [ERROR] at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:230)
    [ERROR] at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:409)
    [ERROR] at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:352)
    [ERROR] Caused by: java.lang.NoSuchMethodError: org.openqa.selenium.io.IOUtils.closeQuietly(Ljava/io/Closeable;)V
    [ERROR] at org.openqa.selenium.firefox.FirefoxProfile.updateUserPrefs(FirefoxProfile.java:333)
    [ERROR] at org.openqa.selenium.firefox.FirefoxProfile.layoutOnDisk(FirefoxProfile.java:450)
    [ERROR] at org.openqa.selenium.firefox.internal.NewProfileExtensionConnection.start(NewProfileExtensionConnection.java:77)
    [ERROR] at org.openqa.selenium.firefox.FirefoxDriver.startClient(FirefoxDriver.java:244)
    [ERROR] at org.openqa.selenium.remote.RemoteWebDriver.<init>(RemoteWebDriver.java:110)
    [ERROR] at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:188)
    [ERROR] at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:183)
    [ERROR] at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:100)
    [ERROR] ... 31 more
    [ERROR] -> [Help 1]
    org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.github.searls:jasmine-maven-plugin:1.3.1.1:test (default) on project myproject: The jasmine-maven-plugin encountered an exception: 
    java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:525)
        at com.github.searls.jasmine.driver.WebDriverFactory.createCustomWebDriver(WebDriverFactory.java:67)
        at com.github.searls.jasmine.driver.WebDriverFactory.createWebDriver(WebDriverFactory.java:47)
        at com.github.searls.jasmine.mojo.TestMojo.createDriver(TestMojo.java:92)
        at com.github.searls.jasmine.mojo.TestMojo.executeSpecs(TestMojo.java:77)
        at com.github.searls.jasmine.mojo.TestMojo.run(TestMojo.java:43)
        at com.github.searls.jasmine.mojo.AbstractJasmineMojo.execute(AbstractJasmineMojo.java:387)
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:101)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:209)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
        at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:319)
        at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:156)
        at org.apache.maven.cli.MavenCli.execute(MavenCli.java:537)
        at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:196)
        at org.apache.maven.cli.MavenCli.main(MavenCli.java:141)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:601)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:290)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:230)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:409)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:352)
    Caused by: java.lang.NoSuchMethodError: org.openqa.selenium.io.IOUtils.closeQuietly(Ljava/io/Closeable;)V
        at org.openqa.selenium.firefox.FirefoxProfile.updateUserPrefs(FirefoxProfile.java:333)
        at org.openqa.selenium.firefox.FirefoxProfile.layoutOnDisk(FirefoxProfile.java:450)
        at org.openqa.selenium.firefox.internal.NewProfileExtensionConnection.start(NewProfileExtensionConnection.java:77)
        at org.openqa.selenium.firefox.FirefoxDriver.startClient(FirefoxDriver.java:244)
        at org.openqa.selenium.remote.RemoteWebDriver.<init>(RemoteWebDriver.java:110)
        at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:188)
        at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:183)
        at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:100)
        ... 31 more

        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:217)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
        at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:319)
        at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:156)
        at org.apache.maven.cli.MavenCli.execute(MavenCli.java:537)
        at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:196)
        at org.apache.maven.cli.MavenCli.main(MavenCli.java:141)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:601)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:290)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:230)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:409)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:352)
    Caused by: org.apache.maven.plugin.MojoExecutionException: The jasmine-maven-plugin encountered an exception: 
    java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:525)
        at com.github.searls.jasmine.driver.WebDriverFactory.createCustomWebDriver(WebDriverFactory.java:67)
        at com.github.searls.jasmine.driver.WebDriverFactory.createWebDriver(WebDriverFactory.java:47)
        at com.github.searls.jasmine.mojo.TestMojo.createDriver(TestMojo.java:92)
        at com.github.searls.jasmine.mojo.TestMojo.executeSpecs(TestMojo.java:77)
        at com.github.searls.jasmine.mojo.TestMojo.run(TestMojo.java:43)
        at com.github.searls.jasmine.mojo.AbstractJasmineMojo.execute(AbstractJasmineMojo.java:387)
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:101)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:209)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
        at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:319)
        at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:156)
        at org.apache.maven.cli.MavenCli.execute(MavenCli.java:537)
        at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:196)
        at org.apache.maven.cli.MavenCli.main(MavenCli.java:141)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:601)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:290)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:230)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:409)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:352)
    Caused by: java.lang.NoSuchMethodError: org.openqa.selenium.io.IOUtils.closeQuietly(Ljava/io/Closeable;)V
        at org.openqa.selenium.firefox.FirefoxProfile.updateUserPrefs(FirefoxProfile.java:333)
        at org.openqa.selenium.firefox.FirefoxProfile.layoutOnDisk(FirefoxProfile.java:450)
        at org.openqa.selenium.firefox.internal.NewProfileExtensionConnection.start(NewProfileExtensionConnection.java:77)
        at org.openqa.selenium.firefox.FirefoxDriver.startClient(FirefoxDriver.java:244)
        at org.openqa.selenium.remote.RemoteWebDriver.<init>(RemoteWebDriver.java:110)
        at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:188)
        at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:183)
        at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:100)
        ... 31 more

        at com.github.searls.jasmine.mojo.AbstractJasmineMojo.execute(AbstractJasmineMojo.java:391)
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:101)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:209)
        ... 19 more
    Caused by: java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:525)
        at com.github.searls.jasmine.driver.WebDriverFactory.createCustomWebDriver(WebDriverFactory.java:67)
        at com.github.searls.jasmine.driver.WebDriverFactory.createWebDriver(WebDriverFactory.java:47)
        at com.github.searls.jasmine.mojo.TestMojo.createDriver(TestMojo.java:92)
        at com.github.searls.jasmine.mojo.TestMojo.executeSpecs(TestMojo.java:77)
        at com.github.searls.jasmine.mojo.TestMojo.run(TestMojo.java:43)
        at com.github.searls.jasmine.mojo.AbstractJasmineMojo.execute(AbstractJasmineMojo.java:387)
        ... 21 more
    Caused by: java.lang.NoSuchMethodError: org.openqa.selenium.io.IOUtils.closeQuietly(Ljava/io/Closeable;)V
        at org.openqa.selenium.firefox.FirefoxProfile.updateUserPrefs(FirefoxProfile.java:333)
        at org.openqa.selenium.firefox.FirefoxProfile.layoutOnDisk(FirefoxProfile.java:450)
        at org.openqa.selenium.firefox.internal.NewProfileExtensionConnection.start(NewProfileExtensionConnection.java:77)
        at org.openqa.selenium.firefox.FirefoxDriver.startClient(FirefoxDriver.java:244)
        at org.openqa.selenium.remote.RemoteWebDriver.<init>(RemoteWebDriver.java:110)
        at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:188)
        at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:183)
        at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:100)
        ... 31 more
    [ERROR] 
    [ERROR] Re-run Maven using the -X switch to enable full debug logging.
    [ERROR] 
    [ERROR] For more information about the errors and possible solutions, please read the following articles:
    [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```
