### PR TITLE
Issue #200 allowing to pass phantomjs.cli.args and phantomjs.ghostdriver.cli.args

### DIFF
--- a/src/main/java/com/github/searls/jasmine/driver/ArgumentsPhantomJsDriver.java
+++ b/src/main/java/com/github/searls/jasmine/driver/ArgumentsPhantomJsDriver.java
@@ -1,0 +1,42 @@
+package com.github.searls.jasmine.driver;
+
+import java.util.Map;
+
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.phantomjs.PhantomJSDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.service.DriverService;
+
+public class ArgumentsPhantomJsDriver extends PhantomJSDriver {
+	
+	private static final String ARRAY_SPLIT_CHARACTER = " ";
+	private static final String ARGUMENTS_PREFIX = "--";
+
+	public ArgumentsPhantomJsDriver(Capabilities desiredCapabilities) {
+		super(convertArgumentStringsToArryays(desiredCapabilities));
+	}
+
+	private static Capabilities convertArgumentStringsToArryays(
+			Capabilities desiredCapabilities) {
+		DesiredCapabilities result = new DesiredCapabilities();
+		Map<String, ?> asMap = desiredCapabilities.asMap();
+		for (String capKey : asMap.keySet()) {
+			Object value = asMap.get(capKey);
+			if (value instanceof String) {
+				String valueAsString = (String)value;
+				if (valueAsString.contains(ARGUMENTS_PREFIX)) {
+					String[] valueAsArray = valueAsString.split(ARRAY_SPLIT_CHARACTER);
+					value = valueAsArray;
+				}
+			}
+			result.setCapability(capKey, value);
+		}
+		return result;
+	}
+
+	public ArgumentsPhantomJsDriver(DriverService service,
+			Capabilities desiredCapabilities) {
+		super(service, convertArgumentStringsToArryays(desiredCapabilities));
+	}
+
+}

--- a/src/test/java/com/github/searls/jasmine/driver/ArgumentsPhantomJsDriverTest.java
+++ b/src/test/java/com/github/searls/jasmine/driver/ArgumentsPhantomJsDriverTest.java
@@ -1,0 +1,62 @@
+package com.github.searls.jasmine.driver;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.codehaus.plexus.util.ReflectionUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.openqa.selenium.phantomjs.PhantomJSDriverService;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class ArgumentsPhantomJsDriverTest {
+
+	private static final String ARRAY_CAP_KEY = "phantomjs.cli.args";
+	private DesiredCapabilities capabilities;
+	private ArgumentsPhantomJsDriver driver;
+	
+	@Before
+	public void setupCapabilities() {
+		capabilities = DesiredCapabilities.phantomjs();
+	}
+
+	private void createDriver() {
+		driver = new ArgumentsPhantomJsDriver(capabilities);
+	}
+
+	@Test
+	public void capabilityUsingArrayArgumentsPrefixConventionIsConvertedToStringArrayForOneValue() throws IllegalAccessException {
+		capabilities.setCapability(ARRAY_CAP_KEY, "--webdriver-loglevel=DEBUG");
+		createDriver();
+		List<String> argumentsForPhantomJs = getArgumentsUsedForPhantomJs();
+		assertExpectedArgument(argumentsForPhantomJs, "--webdriver-loglevel=DEBUG");
+	}
+
+	private List<String> getArgumentsUsedForPhantomJs() throws IllegalAccessException {
+		PhantomJSDriverService driverService = (PhantomJSDriverService) ReflectionUtils.getValueIncludingSuperclasses("service", driver.getCommandExecutor());
+		List<String> argumentsForPhantomJs = (List<String>) ReflectionUtils.getValueIncludingSuperclasses("args", driverService);
+		return argumentsForPhantomJs;
+	}
+
+	private void assertExpectedArgument(List<String> argumentsForPhantomJs, String expectedArgument) {
+		boolean found = false;
+		for (String argument : argumentsForPhantomJs) {
+			if (argument.equals(expectedArgument)) found = true;
+		}
+		assertTrue("Expected " + expectedArgument + " as argument", found);
+	}
+	@Test
+	public void capabilityUsingArrayArgumentsPrefixConventionIsConvertedToStringArrayForMultipleValues() throws IllegalAccessException {
+		capabilities.setCapability(ARRAY_CAP_KEY, "--webdriver-loglevel=DEBUG --webdriver-logfile=file.log");
+		createDriver();
+		List<String> argumentsForPhantomJs = getArgumentsUsedForPhantomJs();
+		assertExpectedArgument(argumentsForPhantomJs, "--webdriver-loglevel=DEBUG");
+		assertExpectedArgument(argumentsForPhantomJs, "--webdriver-logfile=file.log");
+	}
+
+}


### PR DESCRIPTION
allows to pass phantom js and ghostdriver arguments as String arrays to phantom js drivers - fixes inability to pass arguments as described in Issue #200 of searls/jasmine-maven-plugin
