### PR TITLE
Project with customRunnerConfiguration fails test phase even when mvn -DskipTests clean install

### DIFF
--- a/features/skipping_tests.feature
+++ b/features/skipping_tests.feature
@@ -10,12 +10,18 @@ Feature: skipping tests
     Then the build should succeed
     And I should not see "Results: 5 specs, 1 failure"
     And I should not see "There were Jasmine spec failures"
-    
+
   Scenario: setting -DskipTests=false
 
     Given I am currently in the "jasmine-webapp-single-failing" project
     When I run "mvn clean test -DskipTests=false"
     Then the build should fail
     And I should see "Results: 5 specs, 1 failure"
-    And I should see "There were Jasmine spec failures"    
+    And I should see "There were Jasmine spec failures"
+
+  Scenario: customRunnerConfiguration is missing but we ran with -DskipTests
+
+      Given I am currently in the "jasmine-webapp-custom-runner-missing" project
+      When I run "mvn clean test -DskipTests"
+      Then the build should succeed
     

--- a/src/main/java/com/github/searls/jasmine/mojo/AbstractJasmineMojo.java
+++ b/src/main/java/com/github/searls/jasmine/mojo/AbstractJasmineMojo.java
@@ -404,7 +404,7 @@ public abstract class AbstractJasmineMojo extends AbstractMojo implements Jasmin
 	private File customRunnerConfigurationFile;
 
 	@Override
-	public final void execute() throws MojoExecutionException, MojoFailureException {
+	public void execute() throws MojoExecutionException, MojoFailureException {
 		this.loadResources();
 
 		this.sources = new ScriptSearch(this.jsSrcDir,this.sourceIncludes,this.sourceExcludes);

--- a/src/main/java/com/github/searls/jasmine/mojo/TestMojo.java
+++ b/src/main/java/com/github/searls/jasmine/mojo/TestMojo.java
@@ -3,6 +3,7 @@ package com.github.searls.jasmine.mojo;
 import java.io.File;
 import java.net.URL;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -33,23 +34,28 @@ public class TestMojo extends AbstractJasmineMojo {
   }
 
   @Override
-  public void run() throws Exception {
+  public void execute() throws MojoExecutionException, MojoFailureException {
     if(!this.isSkipTests()) {
-      ServerManager serverManager = this.getServerManager();
-      try {
-        int port = serverManager.start();
-        setPortProperty(port);
-        this.getLog().info("Executing Jasmine Specs");
-        JasmineResult result = this.executeSpecs(new URL("http://" + this.serverHostname + ":" + port));
-        this.logResults(result);
-        this.throwAnySpecFailures(result);
-      } finally {
-        if (!keepServerAlive) {
-          serverManager.stop();
-        }
-      }
+      super.execute();
     } else {
       this.getLog().info("Skipping Jasmine Specs");
+    }
+  }
+
+  @Override
+  public void run() throws Exception {
+    ServerManager serverManager = this.getServerManager();
+    try {
+      int port = serverManager.start();
+      setPortProperty(port);
+      this.getLog().info("Executing Jasmine Specs");
+      JasmineResult result = this.executeSpecs(new URL("http://" + this.serverHostname + ":" + port));
+      this.logResults(result);
+      this.throwAnySpecFailures(result);
+    } finally {
+      if (!keepServerAlive) {
+        serverManager.stop();
+      }
     }
   }
 

--- a/src/test/java/com/github/searls/jasmine/mojo/TestMojoTest.java
+++ b/src/test/java/com/github/searls/jasmine/mojo/TestMojoTest.java
@@ -29,9 +29,9 @@ public class TestMojoTest {
   }
 
   @Test
-  public void testRunIfSkipIsTrue() throws Exception {
+  public void testExecuteIfSkipIsTrue() throws Exception {
     this.mojo.skipTests = true;
-    this.mojo.run();
+    this.mojo.execute();
     verify(log).info("Skipping Jasmine Specs");
   }
 }


### PR DESCRIPTION
We have a following setup:
1. customConfigurationRunner runner is first extracted to target/ directory (as it comes from external dependency)
2. configure jasmine maven plugin to use this customConfigurationRunner
3. launch the build using mvn -DskipTests install

Jasmine maven plugin fails at not finding the file

Error message:
com.github.searls:jasmine-maven-plugin:1.3.1.2:test (default) on project XY: Invalid value for parameter 'customRunnerConfiguration'. File does not exist: XY/target/jasmine/src/ext/requirejs-config.js

The code should not check this condition if -DskipTests is set
