### PR TITLE
Disable coffeescript compilation when REQUIRE_JS spec is used.

### DIFF
--- a/src/main/java/com/github/searls/jasmine/coffee/HandlesRequestsForCoffee.java
+++ b/src/main/java/com/github/searls/jasmine/coffee/HandlesRequestsForCoffee.java
@@ -10,16 +10,29 @@ import org.eclipse.jetty.http.HttpHeaders;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.util.resource.Resource;
 
+import com.github.searls.jasmine.config.JasmineConfiguration;
 import com.github.searls.jasmine.format.BuildsJavaScriptToWriteFailureHtml;
+import com.github.searls.jasmine.runner.SpecRunnerTemplate;
 
 public class HandlesRequestsForCoffee {
 
   private CoffeeScript coffeeScript = new CoffeeScript();
   private BuildsJavaScriptToWriteFailureHtml buildsJavaScriptToWriteFailureHtml = new BuildsJavaScriptToWriteFailureHtml();
+  private JasmineConfiguration configuration;
 
+  public HandlesRequestsForCoffee(JasmineConfiguration configuration) {
+	  this.configuration = configuration;
+  }
+  
   public void handle(Request baseRequest, HttpServletResponse response, Resource resource) throws IOException {
     baseRequest.setHandled(true);
-    String javascript = compileCoffee(resource);
+    String javascript = null;
+    if (SpecRunnerTemplate.REQUIRE_JS.equals(configuration.getSpecRunnerTemplate())) {
+    	// CoffeeScript RequireJS plugin should be used for translation
+    	javascript = IOUtils.toString(resource.getInputStream(), "UTF-8");
+    } else {
+        javascript = compileCoffee(resource);
+    }
     setHeaders(response, resource, javascript);
     writeResponse(response, javascript);
   }

--- a/src/main/java/com/github/searls/jasmine/server/JasmineResourceHandler.java
+++ b/src/main/java/com/github/searls/jasmine/server/JasmineResourceHandler.java
@@ -12,16 +12,18 @@ import org.eclipse.jetty.util.resource.Resource;
 
 import com.github.searls.jasmine.coffee.DetectsCoffee;
 import com.github.searls.jasmine.coffee.HandlesRequestsForCoffee;
+import com.github.searls.jasmine.config.JasmineConfiguration;
 import com.github.searls.jasmine.runner.CreatesRunner;
 
 public class JasmineResourceHandler extends ResourceHandler {
 
   private final DetectsCoffee detectsCoffee = new DetectsCoffee();
-  private final HandlesRequestsForCoffee handlesRequestsForCoffee = new HandlesRequestsForCoffee();
+  private final HandlesRequestsForCoffee handlesRequestsForCoffee;
   private final CreatesRunner createsRunner;
 
-  public JasmineResourceHandler(CreatesRunner createsRunner) {
+  public JasmineResourceHandler(CreatesRunner createsRunner, JasmineConfiguration configuration) {
     this.createsRunner = createsRunner;
+    this.handlesRequestsForCoffee = new HandlesRequestsForCoffee(configuration);
     setAliases(true);
   }
 

--- a/src/main/java/com/github/searls/jasmine/server/ResourceHandlerConfigurator.java
+++ b/src/main/java/com/github/searls/jasmine/server/ResourceHandlerConfigurator.java
@@ -43,7 +43,7 @@ public class ResourceHandlerConfigurator {
   }
 
   private ResourceHandler createResourceHandler(boolean directory, String absolutePath, String[] welcomeFiles) {
-    ResourceHandler resourceHandler = new JasmineResourceHandler(this.createsRunner);
+    ResourceHandler resourceHandler = new JasmineResourceHandler(this.createsRunner, this.configuration);
     resourceHandler.setDirectoriesListed(directory);
     if (welcomeFiles != null) {
       resourceHandler.setWelcomeFiles(welcomeFiles);

--- a/src/test/java/com/github/searls/jasmine/coffee/HandlesRequestsForCoffeeTest.java
+++ b/src/test/java/com/github/searls/jasmine/coffee/HandlesRequestsForCoffeeTest.java
@@ -19,17 +19,20 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import com.github.searls.jasmine.config.JasmineConfiguration;
 import com.github.searls.jasmine.format.BuildsJavaScriptToWriteFailureHtml;
+import com.github.searls.jasmine.runner.SpecRunnerTemplate;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HandlesRequestsForCoffeeTest {
   private static final String COFFEE = "coffee";
 
-  @InjectMocks HandlesRequestsForCoffee subject = new HandlesRequestsForCoffee();
+  @InjectMocks HandlesRequestsForCoffee subject = new HandlesRequestsForCoffee(null);
 
   @Mock private CoffeeScript coffeeScript = new CoffeeScript();
   @Mock private BuildsJavaScriptToWriteFailureHtml buildsJavaScriptToWriteFailureHtml;
-
+  @Mock private JasmineConfiguration configuration;
+  
   @Mock private Request baseRequest;
   @Mock(answer=Answers.RETURNS_DEEP_STUBS) private HttpServletResponse response;
   @Mock private Resource resource;
@@ -42,6 +45,11 @@ public class HandlesRequestsForCoffeeTest {
   @Before
   public void defaultCoffeeStubbing() throws IOException {
     when(coffeeScript.compile(COFFEE)).thenReturn("blarg!");
+  }
+
+  @Before
+  public void defaultSpecConfigurationStubbing() throws IOException {
+    when(configuration.getSpecRunnerTemplate()).thenReturn(SpecRunnerTemplate.DEFAULT);
   }
 
   @Test
@@ -111,5 +119,14 @@ public class HandlesRequestsForCoffeeTest {
     verify(response.getWriter()).write("win");
   }
 
+  @Test
+  public void whenCoffeeRequestWithREQUIRE_JSThenWriteCoffee() throws IOException {
+	when(configuration.getSpecRunnerTemplate()).thenReturn(SpecRunnerTemplate.REQUIRE_JS);
+	  
+    subject.handle(baseRequest, response, resource);
+
+    verify(response.getWriter()).write(COFFEE);
+    verify(response).setHeader(HttpHeaders.CONTENT_LENGTH,Integer.toString(COFFEE.length()));
+  }
 
 }

--- a/src/test/java/com/github/searls/jasmine/server/JasmineResourceHandlerTest.java
+++ b/src/test/java/com/github/searls/jasmine/server/JasmineResourceHandlerTest.java
@@ -23,6 +23,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.github.searls.jasmine.coffee.DetectsCoffee;
 import com.github.searls.jasmine.coffee.HandlesRequestsForCoffee;
+import com.github.searls.jasmine.config.JasmineConfiguration;
 import com.github.searls.jasmine.runner.CreatesRunner;
 
 @RunWith(PowerMockRunner.class)
@@ -33,6 +34,7 @@ public class JasmineResourceHandlerTest {
   @Mock private DetectsCoffee detectsCoffee;
   @Mock private HandlesRequestsForCoffee handlesRequestsForCoffee;
   @Mock private CreatesRunner createsRunner;
+  @Mock private JasmineConfiguration configuration;
 
   @Mock Request baseRequest;
   @Mock HttpServletRequest request;
@@ -41,7 +43,7 @@ public class JasmineResourceHandlerTest {
 
   @Mock Log log;
 
-  @InjectMocks private final JasmineResourceHandler subject = new JasmineResourceHandler(createsRunner) {
+  @InjectMocks private final JasmineResourceHandler subject = new JasmineResourceHandler(createsRunner, configuration) {
     @Override
     protected Resource getResource(HttpServletRequest request) throws MalformedURLException {
       return JasmineResourceHandlerTest.this.resource;


### PR DESCRIPTION
fixes #87 - updated fix for 'master' branch with same approach as https://github.com/searls/jasmine-maven-plugin/pull/87

Coffee Script compilation is disabled when using REQUIRE_JS spec runner template.
          <specRunnerTemplate>REQUIRE_JS</specRunnerTemplate>
