### PR TITLE
https connections?

### DIFF
--- a/src/main/java/com/github/searls/jasmine/config/JasmineConfiguration.java
+++ b/src/main/java/com/github/searls/jasmine/config/JasmineConfiguration.java
@@ -9,7 +9,8 @@ import com.github.searls.jasmine.model.ScriptSearch;
 import com.github.searls.jasmine.runner.SpecRunnerTemplate;
 
 public interface JasmineConfiguration {
-	File getBasedir();
+
+  File getBasedir();
 	File getJasmineTargetDir();
 
 	String getSrcDirectoryName();

--- a/src/main/java/com/github/searls/jasmine/mojo/TestMojo.java
+++ b/src/main/java/com/github/searls/jasmine/mojo/TestMojo.java
@@ -8,6 +8,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.eclipse.jetty.server.Server;
 import org.openqa.selenium.WebDriver;
 
 import com.github.searls.jasmine.NullLog;
@@ -49,7 +50,7 @@ public class TestMojo extends AbstractJasmineMojo {
       int port = serverManager.start();
       setPortProperty(port);
       this.getLog().info("Executing Jasmine Specs");
-      JasmineResult result = this.executeSpecs(new URL("http://" + this.serverHostname + ":" + port));
+      JasmineResult result = this.executeSpecs(new URL(this.uriScheme+"://" + this.serverHostname + ":" + port));
       this.logResults(result);
       this.throwAnySpecFailures(result);
     } finally {
@@ -59,7 +60,7 @@ public class TestMojo extends AbstractJasmineMojo {
     }
   }
 
-  private ServerManager getServerManager() {
+  private ServerManager getServerManager() throws MojoExecutionException {
     Log log = this.debug ? this.getLog() : new NullLog();
 
     CreatesRunner createsRunner = new CreatesRunner(
@@ -73,7 +74,7 @@ public class TestMojo extends AbstractJasmineMojo {
         this.relativizesFilePaths,
         createsRunner);
 
-    return new ServerManager(configurator);
+    return new ServerManager(new Server(), getConnector(), configurator);
   }
 
   private void setPortProperty(int port) {

--- a/src/main/java/com/github/searls/jasmine/server/ServerManager.java
+++ b/src/main/java/com/github/searls/jasmine/server/ServerManager.java
@@ -2,22 +2,21 @@ package com.github.searls.jasmine.server;
 
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.nio.SelectChannelConnector;
 
 public class ServerManager {
 
   private static final int ANY_PORT = 0;
 
   private final Server server;
+  private final Connector connector;
   private final ResourceHandlerConfigurator configurator;
 
-  public ServerManager(Server server, ResourceHandlerConfigurator configurator) {
-    this.configurator = configurator;
+  public ServerManager(Server server,
+                       Connector connector,
+                       ResourceHandlerConfigurator configurator) {
     this.server = server;
-  }
-
-  public ServerManager(ResourceHandlerConfigurator configurator) {
-    this(new Server(),configurator);
+    this.connector = connector;
+    this.configurator = configurator;
   }
 
   public int start() throws Exception {
@@ -29,7 +28,6 @@ public class ServerManager {
   }
 
   private int startServer(int port) throws Exception {
-    Connector connector = new SelectChannelConnector();
     connector.setPort(port);
 
     this.server.setHandler(this.configurator.createHandler());

--- a/src/test/java/com/github/searls/jasmine/server/ServerManagerTest.java
+++ b/src/test/java/com/github/searls/jasmine/server/ServerManagerTest.java
@@ -1,14 +1,7 @@
 package com.github.searls.jasmine.server;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.verify;
-
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.nio.SelectChannelConnector;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,7 +9,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.powermock.reflect.Whitebox;
+
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ServerManagerTest {
@@ -27,6 +21,9 @@ public class ServerManagerTest {
   @Mock
   private Server server;
 
+  @Mock
+  private Connector connector;
+
   private ServerManager serverManager;
 
   @Captor
@@ -34,16 +31,15 @@ public class ServerManagerTest {
 
   @Before
   public void before() {
-    this.serverManager = new ServerManager(server,configurator);
+    this.serverManager = new ServerManager(server,connector,configurator);
   }
 
   @Test
   public void testStartAnyPort() throws Exception {
     this.serverManager.start();
 
-    verify(this.server).addConnector(connectorCaptor.capture());
-    assertThat(this.connectorCaptor.getValue(),is(instanceOf(SelectChannelConnector.class)));
-    assertThat(this.connectorCaptor.getValue().getPort(),is(0));
+    verify(this.server).addConnector(this.connector);
+    verify(this.connector).setPort(0);
   }
 
   @Test
@@ -51,8 +47,7 @@ public class ServerManagerTest {
     this.serverManager.start(1234);
 
     verify(this.server).addConnector(connectorCaptor.capture());
-    assertThat(this.connectorCaptor.getValue(),is(instanceOf(SelectChannelConnector.class)));
-    assertThat(this.connectorCaptor.getValue().getPort(),is(1234));
+    verify(this.connector).setPort(1234);
   }
 
   @Test
@@ -67,10 +62,4 @@ public class ServerManagerTest {
     verify(this.server).join();
   }
 
-  @Test
-  public void testConstructWithoutServer() throws Exception {
-    ServerManager manager = new ServerManager(this.configurator);
-    Server newServer = Whitebox.getInternalState(manager, Server.class);
-    assertNotNull(newServer);
-  }
 }


### PR DESCRIPTION
It seems Internet explorer needs the client to be on an HTTPS server in order to connect to HTTPS, which makes sense (oddly, chrome and firefox while using this plugin don't care somehow). Is there an option to enable SSL for the jetty server? 
Or is it possible to at least override the configuration of the jetty server being used? I'm not exactly a maven expert so am not sure if this is possible..
