### PR TITLE
Syntax errors fail silently

### DIFF
--- a/features/halt_on_failure.feature
+++ b/features/halt_on_failure.feature
@@ -18,6 +18,14 @@ Feature: halt the build when a spec failure occurs
     Then the build should fail
     And I should see "Results: 5 specs, 4 failures"
     And I should see "There were Jasmine spec failures"
+  
+  Scenario: project with syntax error
+
+    Given I am currently in the "jasmine-webapp-syntax-error" project
+    When I run "mvn clean test"
+    Then the build should fail
+    And I should see ".*JavaScript Console Errors:"
+    And I should see ".*SyntaxError: Parse error"
 
   Scenario: project with no failures
   

--- a/src/main/resources/jasmine-templates/RequireJsSpecRunner.htmltemplate
+++ b/src/main/resources/jasmine-templates/RequireJsSpecRunner.htmltemplate
@@ -6,6 +6,16 @@
   <meta http-equiv="refresh" content="$autoRefreshInterval$">
   $endif$
   <title>Jasmine Spec Runner</title>
+  <script type="text/javascript">
+    window.onerror = function(msg,url,line) {
+      var jserror = document.head.getAttribute('jmp_jserror') || '';
+      if (jserror) {
+        jserror += ':!:';
+      }
+      jserror += msg;
+      document.head.setAttribute('jmp_jserror',jserror);
+    };
+  </script>
   $cssDependencies$
   $javascriptDependencies$
   $preloadScriptTags$

--- a/src/main/resources/jasmine-templates/SpecRunner.htmltemplate
+++ b/src/main/resources/jasmine-templates/SpecRunner.htmltemplate
@@ -6,6 +6,16 @@
   <meta http-equiv="refresh" content="$autoRefreshInterval$">
   $endif$
   <title>Jasmine Spec Runner</title>
+  <script type="text/javascript">
+    window.onerror = function(msg,url,line) {
+      var jserror = document.head.getAttribute('jmp_jserror') || '';
+      if (jserror) {
+        jserror += ':!:';
+      }
+      jserror += msg;
+      document.head.setAttribute('jmp_jserror',jserror);
+    };
+  </script>
   $cssDependencies$
   $javascriptDependencies$
   $allScriptTags$
@@ -15,7 +25,6 @@
     if(window.location.href.indexOf("ManualSpecRunner.html") !== -1) {
       document.body.appendChild(document.createTextNode("Warning: opening this HTML file directly from the file system is deprecated. You should instead try running `mvn jasmine:bdd` from the command line, and then visit `http://localhost:8234` in your browser. "))
     }
-    
 
     var executeJasmineSpecs = function(){
       window.reporter = new jasmine.$reporter$(); jasmine.getEnv().addReporter(reporter);

--- a/src/test/resources/examples/jasmine-webapp-syntax-error/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-syntax-error/pom.xml
@@ -1,0 +1,32 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.github.searls</groupId>
+    <artifactId>jasmine-example-superpom</artifactId>
+    <version>%{project.version}</version>
+  </parent>
+  <artifactId>jasmine-webapp-syntax-error</artifactId>
+  <packaging>war</packaging>
+  <name>Example Webapp using Jasmine Maven Plugin</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.searls</groupId>
+        <artifactId>jasmine-maven-plugin</artifactId>
+        <version>%{project.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <webDriverClassName>org.openqa.selenium.phantomjs.PhantomJSDriver</webDriverClassName>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/examples/jasmine-webapp-syntax-error/src/main/javascript/HelloWorld.js
+++ b/src/test/resources/examples/jasmine-webapp-syntax-error/src/main/javascript/HelloWorld.js
@@ -1,0 +1,5 @@
+var HelloWorld = function() {
+  this.greeting = function() {
+    return "Hello, World";
+  }
+}

--- a/src/test/resources/examples/jasmine-webapp-syntax-error/src/test/javascript/HelloWorldSpec.js
+++ b/src/test/resources/examples/jasmine-webapp-syntax-error/src/test/javascript/HelloWorldSpec.js
@@ -1,0 +1,8 @@
+describe('HelloWorld',function(){
+
+  it('should say hello',function(){
+    var helloWorld = new HelloWorld();
+    expect(helloWorld.greeting()).toBe("Hello, World");
+  });
+
+});

--- a/src/test/resources/examples/jasmine-webapp-syntax-error/src/test/javascript/SyntaxErrorSpec.js
+++ b/src/test/resources/examples/jasmine-webapp-syntax-error/src/test/javascript/SyntaxErrorSpec.js
@@ -1,0 +1,1 @@
+describe('HelloWorld',function {});


### PR DESCRIPTION
Hi team,

I have recently made a syntax mistake while writing unit test:
`describe('some class', function  {});`

Is it expected that this file is just skipped and there is no error output, if it is run through mvn test ?
