### PR TITLE
List boolean capability map values

### DIFF
--- a/src/main/java/com/github/searls/jasmine/mojo/Capability.java
+++ b/src/main/java/com/github/searls/jasmine/mojo/Capability.java
@@ -1,5 +1,6 @@
 package com.github.searls.jasmine.mojo;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -8,7 +9,7 @@ public class Capability {
   private String name;
   private String value;
   private List<String> list;
-  private Map<String,String> map;
+  private Map<String,Object> map;
 
   public String getName() {
     return name;
@@ -34,11 +35,29 @@ public class Capability {
     this.list = list;
   }
 
-  public Map<String, String> getMap() {
+  public Map<String, Object> getMap() {
     return map;
   }
 
-  public void setMap(Map<String, String> map) {
+  public void setMap(Map<String, Object> map) {
+    for (String key : map.keySet()) {
+      String valueStr = (String) map.get(key);
+      if (isListString(valueStr)) {
+        List<String> listValue = Arrays.asList(valueStr.substring(1, valueStr.length() - 1).split(","));
+        map.put(key, listValue);
+      } else if (isBooleanString(valueStr)) {
+        Boolean booleanValue = Boolean.parseBoolean(valueStr);
+        map.put(key, booleanValue);
+      }
+    }
     this.map = map;
+  }
+  
+  private boolean isListString(String str) {
+      return str.charAt(0) == '[' && str.charAt(str.length() - 1) == ']';
+  }
+
+  private boolean isBooleanString(String str) {
+    return "true".equals(str) || "false".equals(str);
   }
 }

--- a/src/main/java/com/github/searls/jasmine/mojo/CapabilityTest.java
+++ b/src/main/java/com/github/searls/jasmine/mojo/CapabilityTest.java
@@ -1,0 +1,31 @@
+package com.github.searls.jasmine.mojo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import edu.emory.mathcs.backport.java.util.Arrays;
+
+public class CapabilityTest {
+
+    @Test
+    public void setMapTest() {
+        Map<String, Object> testMap = new HashMap<String, Object>();
+        testMap.put("detach", "true");
+        testMap.put("args", "[crash-test,no-sandbox]");
+
+        Capability capability = new Capability();
+        capability.setMap(testMap);
+        Map<String, Object> result = capability.getMap();
+        assertTrue((Boolean) result.get("detach"));
+
+        List<String> argsList = Arrays.asList(new String[]{"crash-test", "no-sandbox"});
+        assertEquals(argsList, result.get("args"));
+    }
+
+}

--- a/src/test/java/com/github/searls/jasmine/mojo/CapabilityTest.java
+++ b/src/test/java/com/github/searls/jasmine/mojo/CapabilityTest.java
@@ -1,15 +1,13 @@
 package com.github.searls.jasmine.mojo;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
-
-import edu.emory.mathcs.backport.java.util.Arrays;
 
 public class CapabilityTest {
 


### PR DESCRIPTION
@jhovell @klieber

With this pull request you are able to provide chromeOptions whose value are a boolean or a list, like so

``` xml
<plugin>
  <groupId>com.github.searls</groupId>
  <artifactId>jasmine-maven-plugin</artifactId>
  <version>1.3.1.5-SNAPSHOT</version>
  <executions>
    <execution>
      <id>Run jasmine tests</id>
      <phase>test</phase>
      <goals>
        <goal>test</goal>
      </goals>
    </execution>
  </executions>
  <configuration>
    <webDriverClassName>org.openqa.selenium.chrome.ChromeDriver</webDriverClassName>
    <webDriverCapabilities>
      <capability>
        <name>browserName</name>
        <value>chrome</value>
      </capability>
      <capability>
        <name>chromeOptions</name>
        <map>
          <args>[crash-test,no-sandbox]</args>
          <binary>/usr/bin/google-chrome</binary>
          <detach>true</detach>
        </map>
      </capability>
    </webDriverCapabilities>
  </configuration>
</plugin>
```

I don't particularly like some of the things I had to do to get this to work. Capability is a bean and shouldn't contain logic for setting the map like this, however everything read in the pom was being treated as a string. I'm not that familiar with AbstractMojo, but is there a way you can have it evaluate values with square brackets as a list of strings, and true / false as booleans?
