### PR TITLE
Fix "phantomjs.binary.path" configuration

### DIFF
--- a/src/site/markdown/phantomjs.md
+++ b/src/site/markdown/phantomjs.md
@@ -42,10 +42,7 @@ The above configuration assumes that the `phantomjs` binary is on your systems `
           <configuration>
             <webDriverClassName>org.openqa.selenium.phantomjs.PhantomJSDriver</webDriverClassName>
             <webDriverCapabilities>
-              <capability>
-                <name>phantomjs.binary.path</name>
-                <value>/opt/phantomjs/bin/phantomjs</name>
-              </capability>
+              <phantomjs.binary.path>/opt/phantomjs/bin/phantomjs</phantomjs.binary.path>
             </webDriverCapabilities>
           </configuration>
         </execution>
@@ -93,10 +90,7 @@ Here's an example using `phantomjs-maven-plugin` with the `jasmine-maven-plugin`
           <configuration>
             <webDriverClassName>org.openqa.selenium.phantomjs.PhantomJSDriver</webDriverClassName>
             <webDriverCapabilities>
-              <capability>
-                <name>phantomjs.binary.path</name>
-                <value>${phantomjs.binary}</name>
-              </capability>
+              <phantomjs.binary.path>${phantomjs.binary}</phantomjs.binary.path>
             </webDriverCapabilities>
           </configuration>
         </execution>


### PR DESCRIPTION
Before this fix, I ended up with the following exception:

Caused by: java.lang.IllegalStateException: The path to the driver executable must be set by the phantomjs.binary.path capability/system property/PATH variable; for more information, see https://github.com/ariya/phantomjs/wiki. The latest version can be downloaded from http://phantomjs.org/download.html
