### PR TITLE
added a webjarDirectoryName parameter to make the context from which

### DIFF
--- a/src/main/java/com/github/searls/jasmine/config/JasmineConfiguration.java
+++ b/src/main/java/com/github/searls/jasmine/config/JasmineConfiguration.java
@@ -16,6 +16,8 @@ public interface JasmineConfiguration {
 	String getSrcDirectoryName();
 	String getSpecDirectoryName();
 
+	String getWebjarDirectoryName();
+	
 	ScriptSearch getSources();
 	ScriptSearch getSpecs();
 

--- a/src/main/java/com/github/searls/jasmine/mojo/AbstractJasmineMojo.java
+++ b/src/main/java/com/github/searls/jasmine/mojo/AbstractJasmineMojo.java
@@ -445,6 +445,14 @@ public abstract class AbstractJasmineMojo extends AbstractMojo implements Jasmin
   )
   protected String connectorClass;
 
+	/**
+	 * <p>The context from which webjar scripts will be served.</p>
+	 *
+	 * @since 1.3.1.5
+	 */
+	@Parameter(property="webjarDirectoryName", defaultValue="webjar")
+	protected String webjarDirectoryName;
+
 	@Parameter(defaultValue="${project}", readonly=true)
 	protected MavenProject mavenProject;
 
@@ -516,6 +524,11 @@ public abstract class AbstractJasmineMojo extends AbstractMojo implements Jasmin
 	@Override
 	public String getSpecDirectoryName() {
 		return this.specDirectoryName;
+	}
+
+	@Override
+	public String getWebjarDirectoryName() {
+		return webjarDirectoryName;
 	}
 
 	@Override

--- a/src/main/java/com/github/searls/jasmine/server/ResourceHandlerConfigurator.java
+++ b/src/main/java/com/github/searls/jasmine/server/ResourceHandlerConfigurator.java
@@ -45,7 +45,7 @@ public class ResourceHandlerConfigurator {
     classPathContextHandler.setHandler(new ClassPathResourceHandler(configuration.getProjectClassLoader()));
     classPathContextHandler.setAliases(true);
 
-    ContextHandler webJarsContextHandler = contexts.addContext("/webjar", "");
+    ContextHandler webJarsContextHandler = contexts.addContext("/" + this.configuration.getWebjarDirectoryName(), "");
     webJarsContextHandler.setHandler(new WebJarResourceHandler(configuration.getProjectClassLoader()));
     webJarsContextHandler.setAliases(true);
 


### PR DESCRIPTION
This is a trivial change built on top of recently merged

https://github.com/searls/jasmine-maven-plugin/pull/221

Currently, all webjar scripts are served from a context named "webjar"  Spring Boot webapps require this to be "webjars".  This pull request introduces a single new parameter to JasmineConfiguration, webjarDirectoryName , to allow the context name to be configured.
