### PR TITLE
Ability to connect to remote Selenium server

### DIFF
--- a/src/main/java/com/github/searls/jasmine/mojo/AbstractJasmineMojo.java
+++ b/src/main/java/com/github/searls/jasmine/mojo/AbstractJasmineMojo.java
@@ -51,6 +51,8 @@ public abstract class AbstractJasmineMojo extends AbstractMojo implements Jasmin
 	/**
 	 * Determines the Selenium WebDriver class we'll use to execute the tests. See the Selenium documentation for more details.
 	 * The plugin uses <a href="http://htmlunit.sourceforge.net/">HtmlUnit</a> by default.
+	 * 
+	 * If the remoteWebDriverUrl property is included this property will be ignored.
 	 *
 	 * <p>Some valid examples:</p>
 	 * <ul>
@@ -66,6 +68,14 @@ public abstract class AbstractJasmineMojo extends AbstractMojo implements Jasmin
 	 */
 	@Parameter(defaultValue="org.openqa.selenium.htmlunit.HtmlUnitDriver")
 	protected String webDriverClassName;
+	
+	/**
+	 * A URL used to create a RemoteWebDriver.  If this property is included, webDriverClassName will be ignored.
+	 *
+	 */
+	@Parameter
+	protected String remoteWebDriverUrl;
+
 
 	/**
 	 * <p>Web driver capabilities used to initialize a DesiredCapabilities instance when creating a web driver.</p>

--- a/src/main/java/com/github/searls/jasmine/mojo/TestMojo.java
+++ b/src/main/java/com/github/searls/jasmine/mojo/TestMojo.java
@@ -95,6 +95,7 @@ public class TestMojo extends AbstractJasmineMojo {
     WebDriverFactory factory = new WebDriverFactory();
     factory.setWebDriverCapabilities(webDriverCapabilities);
     factory.setWebDriverClassName(webDriverClassName);
+    factory.setRemoteWebDriverUrl(remoteWebDriverUrl);
     factory.setDebug(debug);
     factory.setBrowserVersion(browserVersion);
     return factory.createWebDriver();


### PR DESCRIPTION
Fixes issue #234.

The user still has to specify `<serverHostname>` for this to work, e.g.:

``` xml
<remoteWebDriverUrl>http://seleniumServer:4444/wd/hub</remoteWebDriverUrl>
<serverHostname>localIpOrHostname</serverHostname>
```
