### PR TITLE
Special values for <serverHostname>: IP and HOSTNAME

### DIFF
--- a/src/main/java/com/github/searls/jasmine/mojo/AbstractJasmineMojo.java
+++ b/src/main/java/com/github/searls/jasmine/mojo/AbstractJasmineMojo.java
@@ -397,7 +397,7 @@ public abstract class AbstractJasmineMojo extends AbstractMojo implements Jasmin
      *
      * @since 1.3.1.4
      */
-    @Parameter(property="jasmine.serverHostname", defaultValue = "localhost")
+    @Parameter(property="jasmine.serverHostname")
     protected String serverHostname;
 
 	/**

--- a/src/main/java/com/github/searls/jasmine/mojo/AbstractJasmineMojo.java
+++ b/src/main/java/com/github/searls/jasmine/mojo/AbstractJasmineMojo.java
@@ -51,6 +51,8 @@ public abstract class AbstractJasmineMojo extends AbstractMojo implements Jasmin
 	/**
 	 * Determines the Selenium WebDriver class we'll use to execute the tests. See the Selenium documentation for more details.
 	 * The plugin uses <a href="http://htmlunit.sourceforge.net/">HtmlUnit</a> by default.
+	 * 
+	 * If the remoteWebDriverUrl property is included this property will be ignored.
 	 *
 	 * <p>Some valid examples:</p>
 	 * <ul>
@@ -66,6 +68,14 @@ public abstract class AbstractJasmineMojo extends AbstractMojo implements Jasmin
 	 */
 	@Parameter(defaultValue="org.openqa.selenium.htmlunit.HtmlUnitDriver")
 	protected String webDriverClassName;
+	
+	/**
+	 * A URL used to create a RemoteWebDriver.  If this property is included, webDriverClassName will be ignored.
+	 *
+	 */
+	@Parameter
+	protected String remoteWebDriverUrl;
+
 
 	/**
 	 * <p>Web driver capabilities used to initialize a DesiredCapabilities instance when creating a web driver.</p>

--- a/src/main/java/com/github/searls/jasmine/mojo/TestMojo.java
+++ b/src/main/java/com/github/searls/jasmine/mojo/TestMojo.java
@@ -95,6 +95,7 @@ public class TestMojo extends AbstractJasmineMojo {
     WebDriverFactory factory = new WebDriverFactory();
     factory.setWebDriverCapabilities(webDriverCapabilities);
     factory.setWebDriverClassName(webDriverClassName);
+    factory.setRemoteWebDriverUrl(remoteWebDriverUrl);
     factory.setDebug(debug);
     factory.setBrowserVersion(browserVersion);
     return factory.createWebDriver();

--- a/src/test/java/com/github/searls/jasmine/mojo/TestMojoTest.java
+++ b/src/test/java/com/github/searls/jasmine/mojo/TestMojoTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.util.Arrays;
 import java.util.Properties;
 
 import org.apache.maven.plugin.logging.Log;
@@ -54,6 +55,22 @@ public class TestMojoTest {
     String ip = mojo.getIP();
     
     System.out.println("IP = " + ip);
+  }
+  
+  @Test
+  public void getIP_multi_homed() {
+    
+    TestMojo mojo = spy(new TestMojo());
+    Log log = mock(Log.class);
+    mojo.setLog(log);
+    
+    when(mojo.getIPList()).thenReturn(Arrays.asList("1.1.1.1", "2.2.2.2"));
+
+    String ip = mojo.getIP();
+    
+    verify(log).warn("More than one IP found: [1.1.1.1, 2.2.2.2]. Might pick the wrong one.");
+    
+    assertEquals("1.1.1.1" , ip);
   }
   
   @Test

--- a/src/test/java/com/github/searls/jasmine/mojo/TestMojoTest.java
+++ b/src/test/java/com/github/searls/jasmine/mojo/TestMojoTest.java
@@ -1,7 +1,11 @@
 package com.github.searls.jasmine.mojo;
 
-import static org.mockito.Mockito.verify;
+import static org.junit.Assert.*;
 
+import static org.mockito.Mockito.*;
+
+import java.net.SocketException;
+import java.net.UnknownHostException;
 import java.util.Properties;
 
 import org.apache.maven.plugin.logging.Log;
@@ -9,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
@@ -33,5 +38,45 @@ public class TestMojoTest {
     this.mojo.skipTests = true;
     this.mojo.execute();
     verify(log).info("Skipping Jasmine Specs");
+  }
+  
+  @Test
+  public void getHostName() {
+    
+    String hostName = mojo.getHostName();
+    
+    System.out.println("Hostname = " + hostName);
+  }
+  
+  @Test
+  public void getIP() {
+    
+    String ip = mojo.getIP();
+    
+    System.out.println("IP = " + ip);
+  }
+  
+  @Test
+  public void processServerHostName() {
+    
+    String remoteWebDriverUrl = "remoteWebDriverUrl";
+    
+    final String fakeIP       = "1.1.1.1";
+    final String fakeHostname = "fakeHostname";
+    
+    TestMojo mojo = spy(new TestMojo());
+    
+    when(mojo.getIP()).thenReturn(fakeIP);
+    when(mojo.getHostName()).thenReturn(fakeHostname);
+    
+    // With remoteWebDriverUrl
+    assertEquals("serverHostname", mojo.processServerHostName("serverHostname", remoteWebDriverUrl));
+    assertEquals(fakeHostname,     mojo.processServerHostName("HOSTNAME",       remoteWebDriverUrl));
+    assertEquals(fakeIP,           mojo.processServerHostName("IP",             remoteWebDriverUrl));
+    assertEquals(fakeIP,           mojo.processServerHostName(null,             remoteWebDriverUrl));
+
+    // Without remoteWebDriverUrl
+    assertEquals("serverHostname", mojo.processServerHostName("serverHostname", null));
+    assertEquals("localhost",      mojo.processServerHostName(null,             null));
   }
 }


### PR DESCRIPTION
Currently, `<serverHostname>` is hard-coded, i.e. it has to be specified on a per-machine basis. To address this, I propose these two "special values":
- `IP`: the current (local) IP. This is the default.
  
  Caveat: in the case of hosts with "complicated networking" (i.e. multi-homed), this might give you the "wrong" IP (i.e. not the one you wanted).
- `HOSTNAME`: the current (local) hostname.
  
  Caveat: must be resolvable by the remote selenium server (i.e. it won't work if the local hostname in not on DNS).
