### PR TITLE
Add shutdown hook to call WebDriver.quit()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,11 +235,6 @@
       <artifactId>webjars-locator</artifactId>
       <version>0.14</version>
     </dependency>
-    <dependency>
-      <groupId>com.outr.javasysmon</groupId>
-      <artifactId>javasysmon_2.10</artifactId>
-      <version>0.3.4</version>
-    </dependency>
 
     <!-- Plugin test deps -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,10 @@
       <name>gejgalis</name>
       <url>https://github.com/gejgalis</url>
     </contributor>
+    <contributor>
+      <name>mfernandes-git</name>
+      <url>https://github.com/mfernandes-git</url>
+    </contributor>
   </contributors>
   <scm>
     <url>https://github.com/searls/jasmine-maven-plugin</url>
@@ -230,6 +234,11 @@
       <groupId>org.webjars</groupId>
       <artifactId>webjars-locator</artifactId>
       <version>0.14</version>
+    </dependency>
+    <dependency>
+      <groupId>com.outr.javasysmon</groupId>
+      <artifactId>javasysmon_2.10</artifactId>
+      <version>0.3.4</version>
     </dependency>
 
     <!-- Plugin test deps -->

--- a/src/main/java/com/github/searls/jasmine/mojo/TestMojo.java
+++ b/src/main/java/com/github/searls/jasmine/mojo/TestMojo.java
@@ -3,6 +3,7 @@ package com.github.searls.jasmine.mojo;
 import java.io.File;
 import java.net.URL;
 
+import com.jezhumble.javasysmon.JavaSysMon;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
@@ -47,6 +48,7 @@ public class TestMojo extends AbstractJasmineMojo {
   @Override
   public void run() throws Exception {
     ServerManager serverManager = this.getServerManager();
+    attachShutDownHook();
     try {
       int port = serverManager.start();
       setPortProperty(port);
@@ -111,4 +113,21 @@ public class TestMojo extends AbstractJasmineMojo {
       throw new MojoFailureException("There were Jasmine spec failures.");
     }
   }
+  
+  protected void attachShutDownHook() {
+    this.getLog().debug("Attaching ShutdownHook");
+    Runtime.getRuntime().addShutdownHook( new Thread() {
+        @Override
+        public void run() {
+            shutdownHook();
+        }
+    } );
+  }
+  
+  protected void shutdownHook() {
+    this.getLog().debug("Cleanup Child Processes");
+    JavaSysMon monitor = new JavaSysMon();
+    monitor.infanticide();
+  }
+  
 }

--- a/src/test/java/com/github/searls/jasmine/mojo/TestMojoTest.java
+++ b/src/test/java/com/github/searls/jasmine/mojo/TestMojoTest.java
@@ -1,7 +1,6 @@
 package com.github.searls.jasmine.mojo;
 
 import static org.mockito.Mockito.verify;
-//import static org.junit.Assert.assertTrue;
 
 import com.sun.jna.Platform;
 import java.util.Properties;

--- a/src/test/java/com/github/searls/jasmine/mojo/TestMojoTest.java
+++ b/src/test/java/com/github/searls/jasmine/mojo/TestMojoTest.java
@@ -2,7 +2,6 @@ package com.github.searls.jasmine.mojo;
 
 import static org.mockito.Mockito.verify;
 
-import com.sun.jna.Platform;
 import java.util.Properties;
 
 import org.apache.maven.plugin.logging.Log;
@@ -10,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.openqa.selenium.WebDriver;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
@@ -23,6 +23,9 @@ public class TestMojoTest {
   @Mock
   private Properties properties;
 
+  @Mock
+  private WebDriver driver;
+  
   @Before
   public void before() {
     this.mojo = new TestMojo();
@@ -36,22 +39,13 @@ public class TestMojoTest {
     verify(log).info("Skipping Jasmine Specs");
   }
   
-  @Test(timeout = 10000)
+  @Test
   public void testCleanupChildProcessesInShutdownHook() throws Exception {
-    ProcessBuilder builder;
-    Process process;
-    if ( Platform.isWindows() ) {
-      builder = new ProcessBuilder( "timeout", "60" );
-    } else {
-      builder = new ProcessBuilder( "sleep", "60" );
-    }
-    process = builder.start();
-    Thread.sleep( 1000 );
-    this.mojo.attachShutDownHook();
+    this.mojo.attachShutDownHook(driver);
     verify(log).debug("Attaching ShutdownHook");
-    this.mojo.shutdownHook();
+    this.mojo.shutdownHook(driver);
     verify(log).debug("Cleanup Child Processes");
-    process.waitFor();
+	verify(driver).quit();
   }
   
 }

--- a/src/test/java/com/github/searls/jasmine/mojo/TestMojoTest.java
+++ b/src/test/java/com/github/searls/jasmine/mojo/TestMojoTest.java
@@ -46,7 +46,6 @@ public class TestMojoTest {
     } else {
       builder = new ProcessBuilder( "sleep", "60" );
     }
-//    long start = System.currentTimeMillis();
     process = builder.start();
     Thread.sleep( 1000 );
     this.mojo.attachShutDownHook();
@@ -54,8 +53,6 @@ public class TestMojoTest {
     this.mojo.shutdownHook();
     verify(log).debug("Cleanup Child Processes");
     process.waitFor();
-//    long now = System.currentTimeMillis();
-//    assertTrue( (now - start) < 10 * 1000 );
   }
   
 }

--- a/src/test/java/com/github/searls/jasmine/mojo/TestMojoTest.java
+++ b/src/test/java/com/github/searls/jasmine/mojo/TestMojoTest.java
@@ -1,7 +1,9 @@
 package com.github.searls.jasmine.mojo;
 
 import static org.mockito.Mockito.verify;
+//import static org.junit.Assert.assertTrue;
 
+import com.sun.jna.Platform;
 import java.util.Properties;
 
 import org.apache.maven.plugin.logging.Log;
@@ -34,4 +36,26 @@ public class TestMojoTest {
     this.mojo.execute();
     verify(log).info("Skipping Jasmine Specs");
   }
+  
+  @Test(timeout = 10000)
+  public void testCleanupChildProcessesInShutdownHook() throws Exception {
+    ProcessBuilder builder;
+    Process process;
+    if ( Platform.isWindows() ) {
+      builder = new ProcessBuilder( "timeout", "60" );
+    } else {
+      builder = new ProcessBuilder( "sleep", "60" );
+    }
+//    long start = System.currentTimeMillis();
+    process = builder.start();
+    Thread.sleep( 1000 );
+    this.mojo.attachShutDownHook();
+    verify(log).debug("Attaching ShutdownHook");
+    this.mojo.shutdownHook();
+    verify(log).debug("Cleanup Child Processes");
+    process.waitFor();
+//    long now = System.currentTimeMillis();
+//    assertTrue( (now - start) < 10 * 1000 );
+  }
+  
 }


### PR DESCRIPTION
Hello,

It is possible on Windows 7 machines to have an orphaned phantomjs process running.
In example : 
1) Create a project that uses jasmine-maven-plugin with PhantomJSDriver
2) Run mvn clean install
3) At the moment that phantomjs is launched, do a ctrl-c to kill maven

The phantomjs process is not terminated with the maven process.   phantomjs must be killed manually

This is not a problem on linux machines.  Only Windows.

The shutdown hook calls WebDriver.quit()

best regards,
Mark
