### PR TITLE
Write time to test case report if available

### DIFF
--- a/src/main/resources/lib/createJunitXml.js
+++ b/src/main/resources/lib/createJunitXml.js
@@ -54,7 +54,7 @@ var junitXmlReporter;
       writer.beginNode('testcase');
       writer.attrib('classname','jasmine');
       writer.attrib('name',name);
-      writer.attrib('time','0.0');
+      writer.attrib('time',''+specResult.time || '0.0');
 
       if(skipped) {
         this.writeSkipped(writer);


### PR DESCRIPTION
If specResult contains a 'time' variable, write this value.
If variable doesnt exist write the default '0.0'