### PR TITLE
Fixed test result time logic for undefined number

### DIFF
--- a/src/main/resources/lib/createJunitXml.js
+++ b/src/main/resources/lib/createJunitXml.js
@@ -54,7 +54,7 @@ var junitXmlReporter;
       writer.beginNode('testcase');
       writer.attrib('classname','jasmine');
       writer.attrib('name',name);
-      writer.attrib('time',''+specResult.time || '0.0');
+      writer.attrib('time',''+(specResult.time || '0.0'));
 
       if(skipped) {
         this.writeSkipped(writer);


### PR DESCRIPTION
The original implementation below:
<code>writer.attrib('time',''+specResult.time || '0.0');</code>

where we would have an operator precedence issue here because the "+" is evaluated before "||" so we will never have '0.0'.

A fix below:
<code>writer.attrib('time',''+(specResult.time || '0.0'));</code>

where I simply add a pair of brackets so the "||" will be evaluated first.

Thanks and regards,
Moom