### PR TITLE
Document use of classpath selector

### DIFF
--- a/src/site/markdown/webjars-support.md.vm
+++ b/src/site/markdown/webjars-support.md.vm
@@ -75,3 +75,40 @@ Example:
   </build>
 </project>
 ```
+Or use a general syntax for selecting files from the classpath
+
+Example:
+
+```xml
+<project>
+  ...
+  <dependencies>
+    <dependency>
+        <groupId>org.webjars</groupId>
+        <artifactId>jquery</artifactId>
+        <version>1.9.0</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>${project.artifactId}</artifactId>
+        <version>${currentStableVersion}<version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <preloadSources>
+            <source>classpath/META-INF/resources/webjars/jquery/1.9.0/jquery.js</source>
+          </preloadSources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+```


### PR DESCRIPTION
The syntax with the 'classpath' selector is very useful for jars that contain so called web fragments. Webjars are just an example where this mechanism is used.