### PR TITLE
Add integration test with JSCover Proxy Maven Plugin.

### DIFF
--- a/features/integration.feature
+++ b/features/integration.feature
@@ -9,3 +9,12 @@ Feature: integrate with other plugins
     And I should see "Writing CSV coverage report"
     And the file "target/coverage/total-report.csv" should contain "src/HelloWorld.js,3,3,100%"
 
+  Scenario: integrate with jscover-maven-plugin
+
+    Given I am currently in the "jasmine-webapp-jscover-integration" project
+    When I run "mvn clean verify"
+    Then the build should succeed
+    And I should see "Results: 1 specs, 0 failures"
+    And I should see "Finished JSCoverProxy"
+    And the file "target/coverage/jscoverage.json" should contain "{"/src/HelloWorld.js":{"lineData":[null,1,1,1],"functionData":[1,1],"branchData":{}}}"
+

--- a/src/site/markdown/code-coverage.md.vm
+++ b/src/site/markdown/code-coverage.md.vm
@@ -1,7 +1,11 @@
-Integrating with Saga Code Coverage
-===================================
-It is possible to configure your build to run Jasmine tests with the jasmine-maven-plugin and measure code coverage using the fantastic [saga-maven-plugin](http://timurstrekalov.github.com/saga/).
+Integrating with Code Coverage Tools
+====================================
+It is possible to configure your build to run Jasmine tests with the jasmine-maven-plugin and measure code coverage in two ways:
+* the fantastic [saga-maven-plugin](http://timurstrekalov.github.com/saga/)
+* [JSCover](https://github.com/tntim96/JSCover) via [jscoverproxy-maven-plugin](https://github.com/digitalfondue/jscoverproxy-maven-plugin)
 
+Integrating with Saga Code Coverage
+-----------------------------------
 Note: Starting with version `1.3.1.0` of the jasmine-maven-plugin you will need to use the new `keepServerAlive` parameter to keep the web server running and you must use version `1.4.0` of the saga-maven-plugin in order to have saga consume your tests.
 
 Here is an example configuration:
@@ -13,16 +17,16 @@ Here is an example configuration:
       <groupId>${project.groupId}</groupId>
       <artifactId>${project.artifactId}</artifactId>
       <version>${currentStableVersion}<version>
-      <executions>
-        <execution>
-          <goals>
-            <goal>test</goal>
-          </goals>
-          <configuration>
-	    <keepServerAlive>true</keepServerAlive>
-          </configuration>
-        </execution>
-      </executions>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <keepServerAlive>true</keepServerAlive>
+            </configuration>
+          </execution>
+        </executions>
     </plugin>
     <plugin>
       <groupId>com.github.timurstrekalov</groupId>
@@ -48,3 +52,51 @@ Here is an example configuration:
 ```
 
 Then running `mvn verify` should create your coverage reports in `${project.build.directory}/coverage`.
+
+Integrating with JSCover Code Coverage
+--------------------------------------
+Here is an example configuration:
+
+```xml
+<build>
+  <plugins>
+    <plugin>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>${project.artifactId}</artifactId>
+      <version>${currentStableVersion}<version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <keepServerAlive>true</keepServerAlive>
+            </configuration>
+          </execution>
+        </executions>
+    </plugin>
+    <plugin>
+      <groupId>ch.digitalfondue.jscover</groupId>
+      <artifactId>jscoverproxy-maven-plugin</artifactId>
+      <version>1.0</version>
+      <executions>
+        <execution>
+          <goals>
+            <goal>coverage</goal>
+          </goals>
+        </execution>
+      </executions>
+      <configuration>
+        <baseUrl>http://localhost:${jasmine.serverPort}</baseUrl>
+        <outputDir>${project.build.directory}</outputDir>
+        <noInstruments>
+          <pattern>spec/</pattern>
+        </noInstruments>
+      </configuration>
+    </plugin>
+  </plugins>
+</build>
+```
+
+Then running `mvn verify` should create your coverage reports in `${project.build.directory}/coverage`.
+

--- a/src/test/resources/examples/jasmine-webapp-jscover-integration/pom.xml
+++ b/src/test/resources/examples/jasmine-webapp-jscover-integration/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.github.searls</groupId>
+    <artifactId>jasmine-example-superpom</artifactId>
+    <version>%{project.version}</version>
+  </parent>
+  <artifactId>jasmine-webapp-jscover-integration</artifactId>
+  <packaging>war</packaging>
+  <name>Example using Jasmine Maven Plugin with JSCover Proxy Maven Plugin</name>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.searls</groupId>
+        <artifactId>jasmine-maven-plugin</artifactId>
+        <version>%{project.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <keepServerAlive>true</keepServerAlive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>ch.digitalfondue.jscover</groupId>
+        <artifactId>jscoverproxy-maven-plugin</artifactId>
+        <version>1.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>coverage</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <baseUrl>http://localhost:${jasmine.serverPort}</baseUrl>
+          <jsSrcDir>src/main/javascript</jsSrcDir>
+          <outputDir>${project.build.directory}</outputDir>
+          <noInstruments>
+            <pattern>classpath/</pattern>
+            <pattern>webjars/</pattern>
+            <pattern>spec/</pattern>
+          </noInstruments>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/examples/jasmine-webapp-jscover-integration/src/main/javascript/HelloWorld.js
+++ b/src/test/resources/examples/jasmine-webapp-jscover-integration/src/main/javascript/HelloWorld.js
@@ -1,0 +1,5 @@
+var HelloWorld = function() {
+  this.greeting = function() {
+    return "Hello, World";
+  }
+}

--- a/src/test/resources/examples/jasmine-webapp-jscover-integration/src/test/javascript/HelloWorldSpec.js
+++ b/src/test/resources/examples/jasmine-webapp-jscover-integration/src/test/javascript/HelloWorldSpec.js
@@ -1,0 +1,8 @@
+describe('HelloWorld',function(){
+
+  it('should say hello',function(){
+    var helloWorld = new HelloWorld();
+    expect(helloWorld.greeting()).toBe("Hello, World");
+  });
+
+});


### PR DESCRIPTION
This adds the JSCover Proxy Maven Plugin without any other changes to jasmine-maven-plugin.