### PR TITLE
Added option to specify a chromedriver binary and circumvent WebDrive…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,10 @@
       <name>Sam Jones</name>
       <url>https://github.com/samjonester</url>
     </contributor>
+    <contributor>
+      <name>Sven Johansson</name>
+      <url>https://github.com/svjson</url>
+    </contributor>
   </contributors>
   <scm>
     <url>https://github.com/searls/jasmine-maven-plugin</url>

--- a/src/main/java/com/github/searls/jasmine/config/WebDriverConfiguration.java
+++ b/src/main/java/com/github/searls/jasmine/config/WebDriverConfiguration.java
@@ -29,4 +29,5 @@ public interface WebDriverConfiguration {
   boolean isDebug();
   String getWebDriverClassName();
   List<Capability> getWebDriverCapabilities();
+  boolean isWebDriverDownloadEnabled();
 }

--- a/src/main/java/com/github/searls/jasmine/driver/DriverManagerAdapter.java
+++ b/src/main/java/com/github/searls/jasmine/driver/DriverManagerAdapter.java
@@ -1,0 +1,18 @@
+package com.github.searls.jasmine.driver;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+
+class DriverManagerAdapter {
+
+  public void setupDriver(Class<? extends WebDriver> driverClass) {
+    WebDriverManager.getInstance(driverClass).setup();
+  }
+
+  public WebDriver createChromeDriver(ChromeOptions chromeOptions) {
+    return new ChromeDriver(chromeOptions);
+  }
+
+}

--- a/src/main/java/com/github/searls/jasmine/mojo/TestMojo.java
+++ b/src/main/java/com/github/searls/jasmine/mojo/TestMojo.java
@@ -110,6 +110,14 @@ public class TestMojo extends AbstractJasmineMojo {
   private List<Capability> webDriverCapabilities = Collections.emptyList();
 
   /**
+   * <p>Controls whether the configured web driver should be automatically downloaded</p>
+   * <br/>
+   * <p>Default value is <i>true</i>. If set to <i>false</i> the environment must be configured manually.</p>
+   */
+  @Parameter
+  private Boolean webDriverDownloadEnabled = Boolean.TRUE;
+
+  /**
    * <p>Determines the format that jasmine:test will print to console.</p>
    * <p>Valid options:</p>
    * <ul>
@@ -274,6 +282,7 @@ public class TestMojo extends AbstractJasmineMojo {
       .debug(this.debug)
       .webDriverCapabilities(webDriverCapabilities)
       .webDriverClassName(webDriverClassName)
+      .webDriverDownloadEnabled(webDriverDownloadEnabled)
       .build();
   }
 


### PR DESCRIPTION
Added option to specify a chromedriver binary and circumvent WebDriverManager

Rationale:
Environments such as the build machines that our team is using do not have access to the internet, only our local repository mirrors. Currently, the jasmine-maven-plugin is hard-wired to use WebDriverManager that resolves the requested webdriver and installs it. This patch adds the option to point out a pre-installed chromedriver binary without utilizing WebDriverManager.

Notes:
As this patch changes some of the code structure(ie, WebDriverFactory now requires to be instantiated and its methods are no longer static), and to be honest, hasn't really been tried out with other webdriver flavours, I am expecting some homework to be done on the patch before it is merged.