### PR TITLE
feat: Report test progress in near real-time during maven build

### DIFF
--- a/src/main/java/com/github/searls/jasmine/runner/SpecRunnerExecutor.java
+++ b/src/main/java/com/github/searls/jasmine/runner/SpecRunnerExecutor.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -42,12 +42,12 @@ public class SpecRunnerExecutor {
   private static final Logger LOGGER = LoggerFactory.getLogger(SpecRunnerExecutor.class);
 
   private final IoUtilities ioUtilities;
-  private final WebDriverWaiter webDriverWaiter;
+  private final WebDriverJasmineObserver webDriverWaiter;
   private final ConsoleErrorChecker consoleErrorChecker;
 
   @Inject
   public SpecRunnerExecutor(IoUtilities ioUtilities,
-                            WebDriverWaiter webDriverWaiter,
+                            WebDriverJasmineObserver webDriverWaiter,
                             ConsoleErrorChecker consoleErrorChecker) {
     this.ioUtilities = ioUtilities;
     this.webDriverWaiter = webDriverWaiter;

--- a/src/main/resources/jasmine-templates/SpecRunner.htmltemplate
+++ b/src/main/resources/jasmine-templates/SpecRunner.htmltemplate
@@ -21,6 +21,25 @@
   $cssDependencies$
   $javascriptDependencies$
   <script type="text/javascript">
+    var progress = [],
+        indentLevel = 0;
+    window.jsApiReporter.originalSuiteStarted = window.jsApiReporter.suiteStarted;
+    window.jsApiReporter.originalSuiteDone = window.jsApiReporter.suiteDone;
+    window.jsApiReporter.originalSpecDone = window.jsApiReporter.specDone;
+
+    window.jsApiReporter.suiteStarted = function(result) {
+      progress.push(new Array(indentLevel).join(' ') + ' * ' + result.description);
+      indentLevel += 2;
+      this.originalSuiteStarted(result);
+    }
+    window.jsApiReporter.specDone = function(result) {
+      progress.push(new Array(indentLevel).join(' ') + (result.status === 'passed' ? ' - ' : ' X - ERROR - ') + result.description);
+      this.originalSpecDone(result);
+    }
+    window.jsApiReporter.suiteDone = function(result) {
+      indentLevel -= 2;
+      this.originalSuiteDone(result);
+    }
     window.onload = jasmine.boot;
   </script>
   $allScriptTags$

--- a/src/test/java/com/github/searls/jasmine/runner/SpecRunnerExecutorTest.java
+++ b/src/test/java/com/github/searls/jasmine/runner/SpecRunnerExecutorTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -53,7 +53,7 @@ public class SpecRunnerExecutorTest {
   private IoUtilities ioUtilities;
 
   @Mock
-  private WebDriverWaiter webDriverWaiter;
+  private WebDriverJasmineObserver webDriverWaiter;
 
   @Mock
   private ConsoleErrorChecker consoleErrorChecker;

--- a/src/test/java/com/github/searls/jasmine/runner/WebDriverJasmineObserverTest.java
+++ b/src/test/java/com/github/searls/jasmine/runner/WebDriverJasmineObserverTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,7 +31,7 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class WebDriverWaiterTest {
+public class WebDriverJasmineObserverTest {
 
   private static final int TIMEOUT = 2;
 
@@ -42,12 +42,12 @@ public class WebDriverWaiterTest {
   private RemoteWebDriver webDriver;
 
   @InjectMocks
-  private WebDriverWaiter subject;
+  private WebDriverJasmineObserver subject;
 
   @Test
   public void itShouldWait() throws Exception {
     boolean debug = false;
-    when(webDriver.executeScript(WebDriverWaiter.EXECUTION_FINISHED_SCRIPT)).thenReturn(true);
+    when(webDriver.executeScript(WebDriverJasmineObserver.EXECUTION_FINISHED_SCRIPT)).thenReturn(true);
 
     subject.waitForRunnerToFinish(webDriver, TIMEOUT, debug);
   }
@@ -58,7 +58,7 @@ public class WebDriverWaiterTest {
     expectedException.expectMessage("Timeout occurred.");
 
     boolean debug = false;
-    when(webDriver.executeScript(WebDriverWaiter.EXECUTION_FINISHED_SCRIPT)).thenReturn(false);
+    when(webDriver.executeScript(WebDriverJasmineObserver.EXECUTION_FINISHED_SCRIPT)).thenReturn(false);
 
     subject.waitForRunnerToFinish(webDriver, TIMEOUT, debug);
   }
@@ -66,7 +66,7 @@ public class WebDriverWaiterTest {
   @Test
   public void itShouldLogWhenTimesOutDebugging() throws Exception {
     boolean debug = true;
-    when(webDriver.executeScript(WebDriverWaiter.EXECUTION_FINISHED_SCRIPT)).thenReturn(false);
+    when(webDriver.executeScript(WebDriverJasmineObserver.EXECUTION_FINISHED_SCRIPT)).thenReturn(false);
 
     subject.waitForRunnerToFinish(webDriver, TIMEOUT, debug);
   }


### PR DESCRIPTION
What: Added reporting of test progress during build. Outputs suites and specs in a tree structure, and marks failed specs as being in error.

Why: One of our projects currently has ca 1300 specs and takes 3-4 minutes to run. When building the project there is no console output at all during this period. Also, when specs fail it was previously very hard to determine which ones were in error.