### PR TITLE
Do not override dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -393,13 +393,6 @@
               <jasmineVersion>${jasmine.version}</jasmineVersion>
             </attributes>
           </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>org.apache.maven.doxia</groupId>
-              <artifactId>doxia-module-markdown</artifactId>
-              <version>1.10</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Avoid:
```
Execution default-site of goal org.apache.maven.plugins:maven-site-plugin:3.9.1:site failed:
 An API incompatibility was encountered while executing org.apache.maven.plugins:maven-site-plugin:3.9.1:site:
   java.lang.AbstractMethodError:
     Receiver class org.apache.maven.doxia.module.markdown.MarkdownParser does not define or inherit
     an implementation of the resolved method 'abstract void parse(java.io.Reader, org.apache.maven.doxia.sink.Sink)'
     of interface org.apache.maven.doxia.parser.Parser.
```
and allow `site` goal to complete.