### PR TITLE
Fix support for Chrome version ≥117

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <selenium.version>3.141.59</selenium.version>
     <jasmine.version>3.8.0</jasmine.version>
     <mockito.version>4.8.0</mockito.version>
-    <webdrivermanager.version>5.3.0</webdrivermanager.version>
+    <webdrivermanager.version>5.5.2</webdrivermanager.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>


### PR DESCRIPTION
# Issue
https://github.com/searls/jasmine-maven-plugin/issues/598

# Description
Updating the version of `Webdrivermanager` to 5.5.2 fixes the issue.
